### PR TITLE
Whitelist - Evaluate Single Insertions

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -146,7 +146,7 @@ export enum Direction {
 	Backward
 }
 
-export type oneToManyResult = {
+export type OneToManyResult = {
 	duration: number;
 	distance: number;
 };
@@ -155,7 +155,7 @@ export const oneToMany = async (
 	one: Coordinates,
 	many: Coordinates[],
 	direction: Direction
-): Promise<oneToManyResult[]> => {
+): Promise<OneToManyResult[]> => {
 	const dir = direction == Direction.Forward ? 'Forward' : 'Backward';
 	const response = await fetch('https://europe.motis-project.de/', {
 		headers: {

--- a/src/lib/compositionTypes.ts
+++ b/src/lib/compositionTypes.ts
@@ -2,6 +2,20 @@ import type { Capacities } from './capacities';
 import type { Interval } from './interval';
 import type { Coordinates } from './location';
 
+export type Company = {
+	id: number;
+	coordinates: Coordinates;
+	vehicles: Vehicle[];
+	zoneId: number;
+};
+
+export type Vehicle = {
+	id: number;
+	capacities: Capacities;
+	events: Event[];
+	availabilities: Interval[];
+};
+
 export type Event = {
 	capacities: Capacities;
 	is_pickup: boolean;
@@ -9,4 +23,9 @@ export type Event = {
 	id: number;
 	coordinates: Coordinates;
 	tourId: number;
+	arrival: Date;
+	departure: Date;
+	communicated: Date;
+	durationFromPrev: number;
+	durationToNext: number;
 };

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -6,3 +6,7 @@ export const MAX_TRAVEL_DURATION = hoursToMs(1);
 export const MAX_PASSENGER_WAITING_TIME_PICKUP = minutesToMs(10);
 export const MAX_PASSENGER_WAITING_TIME_DROPOFF = minutesToMs(10);
 export const SRID = 4326;
+export const PASSENGER_CHANGE_TIME = minutesToMs(2);
+export const TAXI_DRIVING_TIME_COST_FACTOR = 1;
+export const TAXI_WAITING_TIME_COST_FACTOR = 0.2;
+export const PASSENGER_TIME_COST_FACTOR = 1;

--- a/src/lib/interval.ts
+++ b/src/lib/interval.ts
@@ -65,6 +65,13 @@ export class Interval {
 		);
 	}
 
+	shrink(postponeStart: number, preponeEnd: number) {
+		return new Interval(
+			new Date(this.startTime.getTime() + postponeStart),
+			new Date(this.endTime.getTime() - preponeEnd)
+		);
+	}
+
 	isMergeable(other: Interval): boolean {
 		return this.overlaps(other) || this.touches(other);
 	}
@@ -91,4 +98,35 @@ export class Interval {
 		merged.push(unmerged.pop()!);
 		return merged;
 	};
+
+	intersect(other: Interval): Interval | undefined {
+		if (this.overlaps(other)) {
+			return new Interval(
+				new Date(Math.max(this.startTime.getTime(), other.startTime.getTime())),
+				new Date(Math.min(this.endTime.getTime(), other.endTime.getTime()))
+			);
+		}
+		return undefined;
+	}
+
+	static intersect = (many: Interval[], one: Interval | undefined): Interval[] => {
+		if (one == undefined) {
+			return [];
+		}
+		const result: Interval[] = [];
+		for (let i = 0; i != many.length; ++i) {
+			if (one.startTime.getTime() > many[i].endTime.getTime()) {
+				break;
+			}
+			if (!many[i].overlaps(one)) {
+				continue;
+			}
+			result.push(many[i].intersect(one)!);
+		}
+		return result;
+	};
+
+	covers(time: Date): boolean {
+		return this.startTime <= time && this.endTime >= time;
+	}
 }

--- a/src/lib/interval.ts
+++ b/src/lib/interval.ts
@@ -109,23 +109,6 @@ export class Interval {
 		return undefined;
 	}
 
-	static intersect = (many: Interval[], one: Interval | undefined): Interval[] => {
-		if (one == undefined) {
-			return [];
-		}
-		const result: Interval[] = [];
-		for (let i = 0; i != many.length; ++i) {
-			if (one.startTime.getTime() > many[i].endTime.getTime()) {
-				break;
-			}
-			if (!many[i].overlaps(one)) {
-				continue;
-			}
-			result.push(many[i].intersect(one)!);
-		}
-		return result;
-	};
-
 	covers(time: Date): boolean {
 		return this.startTime <= time && this.endTime >= time;
 	}

--- a/src/lib/time_utils.ts
+++ b/src/lib/time_utils.ts
@@ -9,3 +9,7 @@ export function minutesToMs(minutes: number) {
 export function hoursToMs(hours: number) {
 	return hours * 3600000;
 }
+
+export function yearsToMs(years: number) {
+	return years * 365 * 3600000 * 24;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -137,6 +137,8 @@ export interface EventTable {
 	tour: number;
 	customer: string;
 	request: number;
+	durationToNext: number;
+	durationFromPrev: number;
 }
 
 export type Event = Selectable<EventTable>;

--- a/src/routes/api/booking/+server.ts
+++ b/src/routes/api/booking/+server.ts
@@ -9,6 +9,7 @@ import { MAX_TRAVEL_DURATION, MIN_PREP_MINUTES } from '$lib/constants.js';
 import { sql } from 'kysely';
 import { getFareEstimation } from './fare-estimation/fare_estimation.js';
 import { covers } from '$lib/sqlHelpers.js';
+import type { RequestEvent } from './$types';
 
 const startAndTargetShareZone = async (from: Coordinates, to: Coordinates) => {
 	const zoneContainingStartAndDestination = await db
@@ -18,7 +19,7 @@ const startAndTargetShareZone = async (from: Coordinates, to: Coordinates) => {
 	return zoneContainingStartAndDestination != undefined;
 };
 
-export const POST = async (event) => {
+export const POST = async (event: RequestEvent) => {
 	const customer = event.locals.user;
 	if (!customer) {
 		return error(403);
@@ -427,7 +428,9 @@ export const POST = async (event) => {
 					address: startAddress.id,
 					request: requestId!,
 					tour: tourId!,
-					customer: customerId
+					customer: customerId,
+					durationFromPrev: 0,
+					durationToNext: 0
 				},
 				{
 					is_pickup: false,
@@ -438,7 +441,9 @@ export const POST = async (event) => {
 					address: targetAddress.id,
 					request: requestId!,
 					tour: tourId!,
-					customer: customerId
+					customer: customerId,
+					durationFromPrev: 0,
+					durationToNext: 0
 				}
 			])
 			.execute();

--- a/src/routes/api/whitelist/capacitySimulation.test.ts
+++ b/src/routes/api/whitelist/capacitySimulation.test.ts
@@ -13,7 +13,12 @@ function createEventCapacitiesOnly(capacities: Capacities, is_pickup: boolean): 
 		time: new Interval(now, now),
 		id: 1,
 		coordinates: new Coordinates(1, 1),
-		tourId: 1
+		tourId: 1,
+		arrival: new Date(),
+		departure: new Date(),
+		communicated: new Date(),
+		durationFromPrev: 0,
+		durationToNext: 0
 	};
 }
 

--- a/src/routes/api/whitelist/evaluateSingleInsertions.test.ts
+++ b/src/routes/api/whitelist/evaluateSingleInsertions.test.ts
@@ -31,7 +31,7 @@ const createVehicle = (id: number, events: Event[]): Vehicle => {
 	};
 };
 
-const createEvent = (coordinates: Coordinates): Event => {
+const createEvent = (coordinates: Coordinates, time: number): Event => {
 	return {
 		capacities: { passengers: 0, bikes: 0, wheelchairs: 0, luggage: 0 },
 		is_pickup: true,
@@ -39,7 +39,7 @@ const createEvent = (coordinates: Coordinates): Event => {
 		id: 1,
 		coordinates,
 		tourId: 1,
-		communicated: createDate(6),
+		communicated: createDate(time),
 		arrival: createDate(6),
 		departure: createDate(3),
 		durationFromPrev: 0,
@@ -55,14 +55,15 @@ describe('compute Intervals for single insertions test', () => {
 			createCompany(
 				[
 					createVehicle(1, [
-						createEvent(new Coordinates(eventLatLng, eventLatLng++)),
-						createEvent(new Coordinates(eventLatLng, eventLatLng++)),
-						createEvent(new Coordinates(eventLatLng, eventLatLng++))
+						createEvent(new Coordinates(eventLatLng, eventLatLng++), 4),
+						createEvent(new Coordinates(eventLatLng, eventLatLng++),5),
+						createEvent(new Coordinates(eventLatLng, eventLatLng++),6)
 					])
 				],
 				new Coordinates(companyLatLng, companyLatLng++)
 			)
 		];
+		companies[0].vehicles.forEach((v)=>v.events.forEach((e)=>{e.arrival=createDate(2);e.departure=createDate(7);}));
 		const insertions = new Map<number, Range[]>();
 		insertions.set(1, [{ earliestPickup: 0, latestDropoff: 3 }]);
 		const travelDurations = [50];
@@ -108,7 +109,7 @@ describe('compute Intervals for single insertions test', () => {
 			busStopTimes,
 			[[true]]
 		);
-		console.log(result);
+		console.log("res", result);
 		expect(1).toBe(1);
 	});
 });

--- a/src/routes/api/whitelist/evaluateSingleInsertions.test.ts
+++ b/src/routes/api/whitelist/evaluateSingleInsertions.test.ts
@@ -56,14 +56,19 @@ describe('compute Intervals for single insertions test', () => {
 				[
 					createVehicle(1, [
 						createEvent(new Coordinates(eventLatLng, eventLatLng++), 4),
-						createEvent(new Coordinates(eventLatLng, eventLatLng++),5),
-						createEvent(new Coordinates(eventLatLng, eventLatLng++),6)
+						createEvent(new Coordinates(eventLatLng, eventLatLng++), 5),
+						createEvent(new Coordinates(eventLatLng, eventLatLng++), 6)
 					])
 				],
 				new Coordinates(companyLatLng, companyLatLng++)
 			)
 		];
-		companies[0].vehicles.forEach((v)=>v.events.forEach((e)=>{e.arrival=createDate(2);e.departure=createDate(7);}));
+		companies[0].vehicles.forEach((v) =>
+			v.events.forEach((e) => {
+				e.arrival = createDate(2);
+				e.departure = createDate(7);
+			})
+		);
 		const insertions = new Map<number, Range[]>();
 		insertions.set(1, [{ earliestPickup: 0, latestDropoff: 3 }]);
 		const travelDurations = [50];
@@ -109,7 +114,7 @@ describe('compute Intervals for single insertions test', () => {
 			busStopTimes,
 			[[true]]
 		);
-		console.log("res", result);
+		console.log('res', result);
 		expect(1).toBe(1);
 	});
 });

--- a/src/routes/api/whitelist/evaluateSingleInsertions.test.ts
+++ b/src/routes/api/whitelist/evaluateSingleInsertions.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import { type Range } from './capacitySimulation';
+import { Coordinates } from '$lib/location';
+import { type RoutingResults } from './routing';
+import { computeTravelDurations } from './insertions';
+import type { Vehicle, Company, Event } from '$lib/compositionTypes';
+import { Interval } from '$lib/interval';
+import { hoursToMs } from '$lib/time_utils';
+
+const BASE_MS = new Date(Date.now() + hoursToMs(5)).getTime();
+
+const createDate = (h: number) => {
+	return new Date(BASE_MS + hoursToMs(h));
+};
+
+const createCompany = (vehicles: Vehicle[], coordinates: Coordinates): Company => {
+	return {
+		id: 1,
+		coordinates: coordinates,
+		vehicles,
+		zoneId: 1
+	};
+};
+
+const createVehicle = (id: number, events: Event[]): Vehicle => {
+	return {
+		id,
+		capacities: { passengers: 0, bikes: 0, wheelchairs: 0, luggage: 0 },
+		events,
+		availabilities: []
+	};
+};
+
+const createEvent = (coordinates: Coordinates): Event => {
+	return {
+		capacities: { passengers: 0, bikes: 0, wheelchairs: 0, luggage: 0 },
+		is_pickup: true,
+		time: new Interval(createDate(4), createDate(5)),
+		id: 1,
+		coordinates,
+		tourId: 1,
+		communicated: createDate(6),
+		arrival: createDate(6),
+		departure: createDate(3),
+		durationFromPrev: 0,
+		durationToNext: 0
+	};
+};
+
+describe('compute Intervals for single insertions test', () => {
+	it('TODO', () => {
+		let eventLatLng = 70;
+		let companyLatLng = 5;
+		const companies = [
+			createCompany(
+				[
+					createVehicle(1, [
+						createEvent(new Coordinates(eventLatLng, eventLatLng++)),
+						createEvent(new Coordinates(eventLatLng, eventLatLng++)),
+						createEvent(new Coordinates(eventLatLng, eventLatLng++))
+					])
+				],
+				new Coordinates(companyLatLng, companyLatLng++)
+			)
+		];
+		const insertions = new Map<number, Range[]>();
+		insertions.set(1, [{ earliestPickup: 0, latestDropoff: 3 }]);
+		const travelDurations = [50];
+		const routingResults: RoutingResults = {
+			busStops: [
+				{
+					fromCompany: [{ duration: 10, distance: 0 }],
+					toCompany: [{ duration: 10, distance: 0 }],
+					fromPrevEvent: [
+						{ duration: 10, distance: 0 },
+						{ duration: 10, distance: 0 },
+						{ duration: 10, distance: 0 }
+					],
+					toNextEvent: [
+						{ duration: 10, distance: 0 },
+						{ duration: 10, distance: 0 },
+						{ duration: 10, distance: 0 }
+					]
+				}
+			],
+			userChosen: {
+				fromCompany: [{ duration: 10, distance: 0 }],
+				toCompany: [{ duration: 10, distance: 0 }],
+				fromPrevEvent: [
+					{ duration: 10, distance: 0 },
+					{ duration: 10, distance: 0 },
+					{ duration: 10, distance: 0 }
+				],
+				toNextEvent: [
+					{ duration: 10, distance: 0 },
+					{ duration: 10, distance: 0 },
+					{ duration: 10, distance: 0 }
+				]
+			}
+		};
+		const busStopTimes = [[new Interval(createDate(5), createDate(6))]];
+		const result = computeTravelDurations(
+			companies,
+			insertions,
+			routingResults,
+			travelDurations,
+			true,
+			busStopTimes,
+			[[true]]
+		);
+		console.log(result);
+		expect(1).toBe(1);
+	});
+});

--- a/src/routes/api/whitelist/gatherCoordinates.test.ts
+++ b/src/routes/api/whitelist/gatherCoordinates.test.ts
@@ -1,0 +1,491 @@
+import { describe, it, expect } from 'vitest';
+import { type Range } from './capacitySimulation';
+import { Coordinates } from '$lib/location';
+import type { Vehicle, Company, Event } from '$lib/compositionTypes';
+import { Interval } from '$lib/interval';
+import { gatherRoutingCoordinates } from './routing';
+
+const createCompany = (vehicles: Vehicle[], coordinates: Coordinates): Company => {
+	return {
+		id: 1,
+		coordinates: coordinates,
+		vehicles,
+		zoneId: 1
+	};
+};
+
+const createVehicle = (id: number, events: Event[]): Vehicle => {
+	return {
+		id,
+		capacities: { passengers: 0, bikes: 0, wheelchairs: 0, luggage: 0 },
+		events,
+		availabilities: []
+	};
+};
+
+const createEvent = (coordinates: Coordinates): Event => {
+	return {
+		capacities: { passengers: 0, bikes: 0, wheelchairs: 0, luggage: 0 },
+		is_pickup: true,
+		time: new Interval(new Date(), new Date()),
+		id: 1,
+		coordinates,
+		tourId: 1,
+		arrival: new Date(),
+		departure: new Date(),
+		communicated: new Date(),
+		durationFromPrev: 0,
+		durationToNext: 0
+	};
+};
+
+const createBusStop = () => {
+	return { coordinates: new Coordinates(1, 1), times: [] };
+};
+
+describe('gather coordinates test', () => {
+	it('insertion only possible before first event', () => {
+		let eventLatLng = 100;
+		let companyLatLng = 5;
+		const companies = [
+			createCompany(
+				[
+					createVehicle(1, [
+						createEvent(new Coordinates(eventLatLng, eventLatLng++)),
+						createEvent(new Coordinates(eventLatLng, eventLatLng++))
+					])
+				],
+				new Coordinates(companyLatLng, companyLatLng++)
+			)
+		];
+		const busStops = [createBusStop(), createBusStop()];
+		const busStopCompanyFilter = [[true], [true]];
+		const insertions = new Map<number, Range[]>();
+		insertions.set(1, [{ earliestPickup: 0, latestDropoff: 0 }]);
+		const coordinates = gatherRoutingCoordinates(
+			companies,
+			busStops,
+			insertions,
+			busStopCompanyFilter
+		);
+		expect(coordinates.busStopBackwardMany).toHaveLength(2);
+		expect(coordinates.busStopForwardMany).toHaveLength(2);
+		expect(coordinates.userChosenBackwardMany).toHaveLength(1);
+		expect(coordinates.userChosenForwardMany).toHaveLength(2);
+		busStops.forEach((_, idx) => {
+			expect(coordinates.busStopBackwardMany[idx]).toHaveLength(1);
+			expect(coordinates.busStopForwardMany[idx]).toHaveLength(2);
+		});
+		// company
+		expect(coordinates.userChosenBackwardMany[0].lat).toBe(5);
+		expect(coordinates.userChosenForwardMany[0].lat).toBe(5);
+		expect(coordinates.busStopBackwardMany[0][0].lat).toBe(5);
+		expect(coordinates.busStopForwardMany[0][0].lat).toBe(5);
+		expect(coordinates.busStopBackwardMany[1][0].lat).toBe(5);
+		expect(coordinates.busStopForwardMany[1][0].lat).toBe(5);
+
+		// event
+		expect(coordinates.userChosenBackwardMany[1]).toBe(undefined);
+		expect(coordinates.userChosenForwardMany[1].lat).toBe(100);
+		expect(coordinates.busStopBackwardMany[0][1]).toBe(undefined);
+		expect(coordinates.busStopForwardMany[0][1].lat).toBe(100);
+		expect(coordinates.busStopBackwardMany[1][1]).toBe(undefined);
+		expect(coordinates.busStopForwardMany[1][1].lat).toBe(100);
+	});
+	it('insertion only possible after last event', () => {
+		let eventLatLng = 100;
+		let companyLatLng = 5;
+		const companies = [
+			createCompany(
+				[
+					createVehicle(1, [
+						createEvent(new Coordinates(eventLatLng, eventLatLng++)),
+						createEvent(new Coordinates(eventLatLng, eventLatLng++))
+					])
+				],
+				new Coordinates(companyLatLng, companyLatLng++)
+			)
+		];
+		const busStops = [createBusStop(), createBusStop()];
+		const busStopCompanyFilter = [[true], [true]];
+		const insertions = new Map<number, Range[]>();
+		insertions.set(1, [{ earliestPickup: 2, latestDropoff: 2 }]);
+		const coordinates = gatherRoutingCoordinates(
+			companies,
+			busStops,
+			insertions,
+			busStopCompanyFilter
+		);
+		expect(coordinates.busStopBackwardMany).toHaveLength(2);
+		expect(coordinates.busStopForwardMany).toHaveLength(2);
+		expect(coordinates.userChosenBackwardMany).toHaveLength(2);
+		expect(coordinates.userChosenForwardMany).toHaveLength(1);
+		busStops.forEach((_, idx) => {
+			expect(coordinates.busStopBackwardMany[idx]).toHaveLength(2);
+			expect(coordinates.busStopForwardMany[idx]).toHaveLength(1);
+		});
+		// company
+		expect(coordinates.userChosenBackwardMany[0].lat).toBe(5);
+		expect(coordinates.userChosenForwardMany[0].lat).toBe(5);
+		expect(coordinates.busStopBackwardMany[0][0].lat).toBe(5);
+		expect(coordinates.busStopForwardMany[0][0].lat).toBe(5);
+		expect(coordinates.busStopBackwardMany[1][0].lat).toBe(5);
+		expect(coordinates.busStopForwardMany[1][0].lat).toBe(5);
+
+		// event
+		expect(coordinates.userChosenForwardMany[1]).toBe(undefined);
+		expect(coordinates.userChosenBackwardMany[1].lat).toBe(101);
+		expect(coordinates.busStopForwardMany[0][1]).toBe(undefined);
+		expect(coordinates.busStopBackwardMany[0][1].lat).toBe(101);
+		expect(coordinates.busStopForwardMany[1][1]).toBe(undefined);
+		expect(coordinates.busStopBackwardMany[1][1].lat).toBe(101);
+	});
+	it('insertion only possible between events', () => {
+		let eventLatLng = 100;
+		let companyLatLng = 5;
+		const companies = [
+			createCompany(
+				[
+					createVehicle(1, [
+						createEvent(new Coordinates(eventLatLng, eventLatLng++)),
+						createEvent(new Coordinates(eventLatLng, eventLatLng++))
+					])
+				],
+				new Coordinates(companyLatLng, companyLatLng++)
+			)
+		];
+		const busStops = [createBusStop(), createBusStop()];
+		const busStopCompanyFilter = [[true], [true]];
+		const insertions = new Map<number, Range[]>();
+		insertions.set(1, [{ earliestPickup: 1, latestDropoff: 1 }]);
+		const coordinates = gatherRoutingCoordinates(
+			companies,
+			busStops,
+			insertions,
+			busStopCompanyFilter
+		);
+		expect(coordinates.busStopBackwardMany).toHaveLength(2);
+		expect(coordinates.busStopForwardMany).toHaveLength(2);
+		expect(coordinates.userChosenBackwardMany).toHaveLength(2);
+		expect(coordinates.userChosenForwardMany).toHaveLength(2);
+		busStops.forEach((_, idx) => {
+			expect(coordinates.busStopBackwardMany[idx]).toHaveLength(2);
+			expect(coordinates.busStopForwardMany[idx]).toHaveLength(2);
+		});
+		// company
+		expect(coordinates.userChosenBackwardMany[0].lat).toBe(5);
+		expect(coordinates.userChosenForwardMany[0].lat).toBe(5);
+		expect(coordinates.busStopBackwardMany[0][0].lat).toBe(5);
+		expect(coordinates.busStopForwardMany[0][0].lat).toBe(5);
+		expect(coordinates.busStopBackwardMany[1][0].lat).toBe(5);
+		expect(coordinates.busStopForwardMany[1][0].lat).toBe(5);
+
+		// event
+		expect(coordinates.userChosenForwardMany[1].lat).toBe(101);
+		expect(coordinates.userChosenBackwardMany[1].lat).toBe(100);
+		expect(coordinates.busStopForwardMany[0][1].lat).toBe(101);
+		expect(coordinates.busStopBackwardMany[0][1].lat).toBe(100);
+		expect(coordinates.busStopForwardMany[1][1].lat).toBe(101);
+		expect(coordinates.busStopBackwardMany[1][1].lat).toBe(100);
+	});
+	it('insertion not possible after last event', () => {
+		let eventLatLng = 100;
+		let companyLatLng = 5;
+		const companies = [
+			createCompany(
+				[
+					createVehicle(1, [
+						createEvent(new Coordinates(eventLatLng, eventLatLng++)),
+						createEvent(new Coordinates(eventLatLng, eventLatLng++))
+					])
+				],
+				new Coordinates(companyLatLng, companyLatLng++)
+			)
+		];
+		const busStops = [createBusStop(), createBusStop()];
+		const busStopCompanyFilter = [[true], [true]];
+		const insertions = new Map<number, Range[]>();
+		insertions.set(1, [{ earliestPickup: 0, latestDropoff: 1 }]);
+		const coordinates = gatherRoutingCoordinates(
+			companies,
+			busStops,
+			insertions,
+			busStopCompanyFilter
+		);
+		expect(coordinates.busStopBackwardMany).toHaveLength(2);
+		expect(coordinates.busStopForwardMany).toHaveLength(2);
+		expect(coordinates.userChosenBackwardMany).toHaveLength(2);
+		expect(coordinates.userChosenForwardMany).toHaveLength(3);
+		busStops.forEach((_, idx) => {
+			expect(coordinates.busStopBackwardMany[idx]).toHaveLength(2);
+			expect(coordinates.busStopForwardMany[idx]).toHaveLength(3);
+		});
+		// company
+		expect(coordinates.userChosenBackwardMany[0].lat).toBe(5);
+		expect(coordinates.userChosenForwardMany[0].lat).toBe(5);
+		expect(coordinates.busStopBackwardMany[0][0].lat).toBe(5);
+		expect(coordinates.busStopForwardMany[0][0].lat).toBe(5);
+		expect(coordinates.busStopBackwardMany[1][0].lat).toBe(5);
+		expect(coordinates.busStopForwardMany[1][0].lat).toBe(5);
+
+		// event
+		expect(coordinates.userChosenForwardMany[1].lat).toBe(100);
+		expect(coordinates.userChosenBackwardMany[1].lat).toBe(100);
+		expect(coordinates.busStopForwardMany[0][1].lat).toBe(100);
+		expect(coordinates.busStopBackwardMany[0][1].lat).toBe(100);
+		expect(coordinates.busStopForwardMany[1][1].lat).toBe(100);
+		expect(coordinates.busStopBackwardMany[1][1].lat).toBe(100);
+
+		expect(coordinates.userChosenForwardMany[2].lat).toBe(101);
+		expect(coordinates.userChosenBackwardMany[2]).toBe(undefined);
+		expect(coordinates.busStopForwardMany[0][2].lat).toBe(101);
+		expect(coordinates.busStopBackwardMany[0][2]).toBe(undefined);
+		expect(coordinates.busStopForwardMany[1][2].lat).toBe(101);
+		expect(coordinates.busStopBackwardMany[1][2]).toBe(undefined);
+	});
+	it('2companies, all insertions possible', () => {
+		let eventLatLng = 100;
+		let companyLatLng = 5;
+		const companies = [
+			createCompany(
+				[
+					createVehicle(1, [
+						createEvent(new Coordinates(eventLatLng, eventLatLng++)),
+						createEvent(new Coordinates(eventLatLng, eventLatLng++))
+					])
+				],
+				new Coordinates(companyLatLng, companyLatLng++)
+			),
+			createCompany(
+				[
+					createVehicle(2, [
+						createEvent(new Coordinates(eventLatLng, eventLatLng++)),
+						createEvent(new Coordinates(eventLatLng, eventLatLng++))
+					])
+				],
+				new Coordinates(companyLatLng, companyLatLng++)
+			)
+		];
+		const busStops = [createBusStop(), createBusStop()];
+		const busStopCompanyFilter = [
+			[true, true],
+			[true, true]
+		];
+		const insertions = new Map<number, Range[]>();
+		insertions.set(1, [{ earliestPickup: 0, latestDropoff: 2 }]);
+		insertions.set(2, [{ earliestPickup: 0, latestDropoff: 2 }]);
+		const coordinates = gatherRoutingCoordinates(
+			companies,
+			busStops,
+			insertions,
+			busStopCompanyFilter
+		);
+		expect(coordinates.busStopBackwardMany).toHaveLength(2);
+		expect(coordinates.busStopForwardMany).toHaveLength(2);
+		expect(coordinates.userChosenBackwardMany).toHaveLength(6);
+		expect(coordinates.userChosenForwardMany).toHaveLength(6);
+		busStops.forEach((_, idx) => {
+			expect(coordinates.busStopBackwardMany[idx]).toHaveLength(6);
+			expect(coordinates.busStopForwardMany[idx]).toHaveLength(6);
+		});
+		// Company coordinates
+		expect(coordinates.userChosenBackwardMany[0].lat).toBe(5);
+		expect(coordinates.userChosenForwardMany[0].lat).toBe(5);
+		expect(coordinates.busStopBackwardMany[1][0].lat).toBe(5);
+		expect(coordinates.busStopForwardMany[1][0].lat).toBe(5);
+		expect(coordinates.busStopBackwardMany[0][0].lat).toBe(5);
+		expect(coordinates.busStopForwardMany[0][0].lat).toBe(5);
+		expect(coordinates.userChosenBackwardMany[1].lat).toBe(6);
+		expect(coordinates.userChosenForwardMany[1].lat).toBe(6);
+		expect(coordinates.busStopBackwardMany[0][1].lat).toBe(6);
+		expect(coordinates.busStopForwardMany[0][1].lat).toBe(6);
+		expect(coordinates.busStopBackwardMany[1][1].lat).toBe(6);
+		expect(coordinates.busStopForwardMany[1][1].lat).toBe(6);
+
+		// Event coordinates
+		expect(coordinates.userChosenBackwardMany[2].lat).toBe(100);
+		expect(coordinates.userChosenForwardMany[2].lat).toBe(100);
+		expect(coordinates.busStopBackwardMany[0][2].lat).toBe(100);
+		expect(coordinates.busStopForwardMany[0][2].lat).toBe(100);
+		expect(coordinates.busStopBackwardMany[1][2].lat).toBe(100);
+		expect(coordinates.busStopForwardMany[1][2].lat).toBe(100);
+
+		expect(coordinates.userChosenBackwardMany[3].lat).toBe(101);
+		expect(coordinates.userChosenForwardMany[3].lat).toBe(101);
+		expect(coordinates.busStopBackwardMany[0][3].lat).toBe(101);
+		expect(coordinates.busStopForwardMany[0][3].lat).toBe(101);
+		expect(coordinates.busStopBackwardMany[1][3].lat).toBe(101);
+		expect(coordinates.busStopForwardMany[1][3].lat).toBe(101);
+
+		expect(coordinates.userChosenBackwardMany[4].lat).toBe(102);
+		expect(coordinates.userChosenForwardMany[4].lat).toBe(102);
+		expect(coordinates.busStopBackwardMany[0][4].lat).toBe(102);
+		expect(coordinates.busStopForwardMany[0][4].lat).toBe(102);
+		expect(coordinates.busStopBackwardMany[1][4].lat).toBe(102);
+		expect(coordinates.busStopForwardMany[1][4].lat).toBe(102);
+
+		expect(coordinates.userChosenBackwardMany[5].lat).toBe(103);
+		expect(coordinates.userChosenForwardMany[5].lat).toBe(103);
+		expect(coordinates.busStopBackwardMany[0][5].lat).toBe(103);
+		expect(coordinates.busStopForwardMany[0][5].lat).toBe(103);
+		expect(coordinates.busStopBackwardMany[1][5].lat).toBe(103);
+		expect(coordinates.busStopForwardMany[1][5].lat).toBe(103);
+	});
+	it('2companies, 1 company-busstop combination filtered out', () => {
+		let eventLatLng = 100;
+		let companyLatLng = 5;
+		const companies = [
+			createCompany(
+				[
+					createVehicle(1, [
+						createEvent(new Coordinates(eventLatLng, eventLatLng++)),
+						createEvent(new Coordinates(eventLatLng, eventLatLng++))
+					])
+				],
+				new Coordinates(companyLatLng, companyLatLng++)
+			),
+			createCompany(
+				[
+					createVehicle(2, [
+						createEvent(new Coordinates(eventLatLng, eventLatLng++)),
+						createEvent(new Coordinates(eventLatLng, eventLatLng++))
+					])
+				],
+				new Coordinates(companyLatLng, companyLatLng++)
+			)
+		];
+		const busStops = [createBusStop(), createBusStop()];
+		const busStopCompanyFilter = [
+			[false, true],
+			[true, true]
+		];
+		const insertions = new Map<number, Range[]>();
+		insertions.set(1, [{ earliestPickup: 0, latestDropoff: 2 }]);
+		insertions.set(2, [{ earliestPickup: 0, latestDropoff: 2 }]);
+		const coordinates = gatherRoutingCoordinates(
+			companies,
+			busStops,
+			insertions,
+			busStopCompanyFilter
+		);
+		expect(coordinates.busStopBackwardMany).toHaveLength(2);
+		expect(coordinates.busStopForwardMany).toHaveLength(2);
+		expect(coordinates.userChosenBackwardMany).toHaveLength(6);
+		expect(coordinates.userChosenForwardMany).toHaveLength(6);
+		expect(coordinates.busStopBackwardMany[0]).toHaveLength(3);
+		expect(coordinates.busStopForwardMany[0]).toHaveLength(3);
+		expect(coordinates.busStopBackwardMany[1]).toHaveLength(6);
+		expect(coordinates.busStopForwardMany[1]).toHaveLength(6);
+		// Company coordinates
+		expect(coordinates.userChosenBackwardMany[0].lat).toBe(5);
+		expect(coordinates.userChosenForwardMany[0].lat).toBe(5);
+		expect(coordinates.busStopBackwardMany[1][0].lat).toBe(5);
+		expect(coordinates.busStopForwardMany[1][0].lat).toBe(5);
+		expect(coordinates.busStopBackwardMany[0][0].lat).toBe(6);
+		expect(coordinates.busStopForwardMany[0][0].lat).toBe(6);
+		expect(coordinates.userChosenBackwardMany[1].lat).toBe(6);
+		expect(coordinates.userChosenForwardMany[1].lat).toBe(6);
+		expect(coordinates.busStopBackwardMany[1][1].lat).toBe(6);
+		expect(coordinates.busStopForwardMany[1][1].lat).toBe(6);
+		// Event coordinates
+		expect(coordinates.userChosenBackwardMany[2].lat).toBe(100);
+		expect(coordinates.userChosenForwardMany[2].lat).toBe(100);
+		expect(coordinates.busStopBackwardMany[1][2].lat).toBe(100);
+		expect(coordinates.busStopForwardMany[1][2].lat).toBe(100);
+
+		expect(coordinates.userChosenBackwardMany[3].lat).toBe(101);
+		expect(coordinates.userChosenForwardMany[3].lat).toBe(101);
+		expect(coordinates.busStopBackwardMany[1][3].lat).toBe(101);
+		expect(coordinates.busStopForwardMany[1][3].lat).toBe(101);
+
+		expect(coordinates.userChosenBackwardMany[4].lat).toBe(102);
+		expect(coordinates.userChosenForwardMany[4].lat).toBe(102);
+		expect(coordinates.busStopBackwardMany[0][1].lat).toBe(102);
+		expect(coordinates.busStopForwardMany[0][1].lat).toBe(102);
+		expect(coordinates.busStopBackwardMany[1][4].lat).toBe(102);
+		expect(coordinates.busStopForwardMany[1][4].lat).toBe(102);
+
+		expect(coordinates.userChosenBackwardMany[5].lat).toBe(103);
+		expect(coordinates.userChosenForwardMany[5].lat).toBe(103);
+		expect(coordinates.busStopBackwardMany[0][2].lat).toBe(103);
+		expect(coordinates.busStopForwardMany[0][2].lat).toBe(103);
+		expect(coordinates.busStopBackwardMany[1][5].lat).toBe(103);
+		expect(coordinates.busStopForwardMany[1][5].lat).toBe(103);
+	});
+	it('2companies, 1 busstop filtered out', () => {
+		let eventLatLng = 100;
+		let companyLatLng = 5;
+		const companies = [
+			createCompany(
+				[
+					createVehicle(1, [
+						createEvent(new Coordinates(eventLatLng, eventLatLng++)),
+						createEvent(new Coordinates(eventLatLng, eventLatLng++))
+					])
+				],
+				new Coordinates(companyLatLng, companyLatLng++)
+			),
+			createCompany(
+				[
+					createVehicle(2, [
+						createEvent(new Coordinates(eventLatLng, eventLatLng++)),
+						createEvent(new Coordinates(eventLatLng, eventLatLng++))
+					])
+				],
+				new Coordinates(companyLatLng, companyLatLng++)
+			)
+		];
+		const busStops = [createBusStop(), createBusStop()];
+		const busStopCompanyFilter = [
+			[false, false],
+			[true, true]
+		];
+		const insertions = new Map<number, Range[]>();
+		insertions.set(1, [{ earliestPickup: 0, latestDropoff: 2 }]);
+		insertions.set(2, [{ earliestPickup: 0, latestDropoff: 2 }]);
+		const coordinates = gatherRoutingCoordinates(
+			companies,
+			busStops,
+			insertions,
+			busStopCompanyFilter
+		);
+		expect(coordinates.busStopBackwardMany).toHaveLength(2);
+		expect(coordinates.busStopForwardMany).toHaveLength(2);
+		expect(coordinates.userChosenBackwardMany).toHaveLength(6);
+		expect(coordinates.userChosenForwardMany).toHaveLength(6);
+		expect(coordinates.busStopBackwardMany[0]).toHaveLength(0);
+		expect(coordinates.busStopForwardMany[0]).toHaveLength(0);
+		expect(coordinates.busStopBackwardMany[1]).toHaveLength(6);
+		expect(coordinates.busStopForwardMany[1]).toHaveLength(6);
+		// Company coordinates
+		expect(coordinates.userChosenBackwardMany[0].lat).toBe(5);
+		expect(coordinates.userChosenForwardMany[0].lat).toBe(5);
+		expect(coordinates.busStopBackwardMany[1][0].lat).toBe(5);
+		expect(coordinates.busStopForwardMany[1][0].lat).toBe(5);
+
+		expect(coordinates.userChosenBackwardMany[1].lat).toBe(6);
+		expect(coordinates.userChosenForwardMany[1].lat).toBe(6);
+		expect(coordinates.busStopBackwardMany[1][1].lat).toBe(6);
+		expect(coordinates.busStopForwardMany[1][1].lat).toBe(6);
+		// Event coordinates
+		expect(coordinates.userChosenBackwardMany[2].lat).toBe(100);
+		expect(coordinates.userChosenForwardMany[2].lat).toBe(100);
+		expect(coordinates.busStopBackwardMany[1][2].lat).toBe(100);
+		expect(coordinates.busStopForwardMany[1][2].lat).toBe(100);
+
+		expect(coordinates.userChosenBackwardMany[3].lat).toBe(101);
+		expect(coordinates.userChosenForwardMany[3].lat).toBe(101);
+		expect(coordinates.busStopBackwardMany[1][3].lat).toBe(101);
+		expect(coordinates.busStopForwardMany[1][3].lat).toBe(101);
+
+		expect(coordinates.userChosenBackwardMany[4].lat).toBe(102);
+		expect(coordinates.userChosenForwardMany[4].lat).toBe(102);
+		expect(coordinates.busStopBackwardMany[1][4].lat).toBe(102);
+		expect(coordinates.busStopForwardMany[1][4].lat).toBe(102);
+
+		expect(coordinates.userChosenBackwardMany[5].lat).toBe(103);
+		expect(coordinates.userChosenForwardMany[5].lat).toBe(103);
+		expect(coordinates.busStopBackwardMany[1][5].lat).toBe(103);
+		expect(coordinates.busStopForwardMany[1][5].lat).toBe(103);
+	});
+});

--- a/src/routes/api/whitelist/helpers.test.ts
+++ b/src/routes/api/whitelist/helpers.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { computeCosts, InsertionType, ToInsert, type InsertionDurations } from './insertions';
+
+describe('', () => {
+	it('TODO', () => {
+        const toInsert = ToInsert.PICKUP;
+        const type = InsertionType.APPEND;
+        const durations: InsertionDurations = {
+            approach: 5,
+            return: 10,
+            pickupToDropoff: 5,
+            fromPrev: 5,
+            toNext: 5,
+            fullWindow:15
+        }
+        computeCosts(type, durations, toInsert);
+    });
+});

--- a/src/routes/api/whitelist/helpers.test.ts
+++ b/src/routes/api/whitelist/helpers.test.ts
@@ -3,16 +3,16 @@ import { computeCosts, InsertionType, ToInsert, type InsertionDurations } from '
 
 describe('', () => {
 	it('TODO', () => {
-        const toInsert = ToInsert.PICKUP;
-        const type = InsertionType.APPEND;
-        const durations: InsertionDurations = {
-            approach: 5,
-            return: 10,
-            pickupToDropoff: 5,
-            fromPrev: 5,
-            toNext: 5,
-            fullWindow:15
-        }
-        computeCosts(type, durations, toInsert);
-    });
+		const toInsert = ToInsert.PICKUP;
+		const type = InsertionType.APPEND;
+		const durations: InsertionDurations = {
+			approach: 5,
+			return: 10,
+			pickupToDropoff: 5,
+			fromPrev: 5,
+			toNext: 5,
+			fullWindow: 15
+		};
+		computeCosts(type, durations, toInsert);
+	});
 });

--- a/src/routes/api/whitelist/insertionTypes.ts
+++ b/src/routes/api/whitelist/insertionTypes.ts
@@ -9,9 +9,9 @@ export type InsertionInfo = {
 };
 
 export type InsertionEvaluation = {
-	userChosen: TimeCost|undefined;
-	busStops: TimeCost|undefined[][];
-	both: TimeCost|undefined[][];
+	userChosen: TimeCost | undefined;
+	busStops: TimeCost | undefined[][];
+	both: TimeCost | undefined[][];
 	approachDuration: number | undefined;
 	returnDuration: number | undefined;
 	company: number;

--- a/src/routes/api/whitelist/insertionTypes.ts
+++ b/src/routes/api/whitelist/insertionTypes.ts
@@ -1,0 +1,35 @@
+import type { Vehicle } from '$lib/compositionTypes';
+
+export type InsertionInfo = {
+	companyIdx: number;
+	prevEventIdx: number;
+	nextEventIdx: number;
+	vehicle: Vehicle;
+	insertionIdx: number;
+};
+
+export type InsertionEvaluation = {
+	userChosen: TimeCost|undefined;
+	busStops: TimeCost|undefined[][];
+	both: TimeCost|undefined[][];
+	approachDuration: number | undefined;
+	returnDuration: number | undefined;
+	company: number;
+	vehicle: number;
+	tour1: number;
+	tour2: number;
+	event1: number;
+	event2: number;
+};
+
+export type TimeCost = {
+	time: Date;
+	cost: Cost;
+};
+
+export type Cost = {
+	taxiWaitingTime: number;
+	taxiDrivingDuration: number;
+	passengerDuration: number;
+	total: number;
+};

--- a/src/routes/api/whitelist/insertionTypes.ts
+++ b/src/routes/api/whitelist/insertionTypes.ts
@@ -2,8 +2,9 @@ import type { Vehicle } from '$lib/compositionTypes';
 
 export type InsertionInfo = {
 	companyIdx: number;
-	prevEventIdx: number;
-	nextEventIdx: number;
+	companyIdxInRoutingResults: number;
+	prevEventIdxInRoutingResults: number;
+	nextEventIdxInRoutingResults: number;
 	vehicle: Vehicle;
 	insertionIdx: number;
 };

--- a/src/routes/api/whitelist/insertions.ts
+++ b/src/routes/api/whitelist/insertions.ts
@@ -45,6 +45,7 @@ type TimeCost = {
 	cost: Cost;
 	approachDuration: number;
 	returnDuration: number;
+	type: InsertionType;
 };
 
 type Insertion = {
@@ -114,7 +115,8 @@ export function evaluateInsertion(
 		time: startFixed ? arrivalWindow.startTime : arrivalWindow.endTime,
 		cost,
 		approachDuration: durations.approach,
-		returnDuration: durations.return
+		returnDuration: durations.return,
+		type
 	};
 }
 

--- a/src/routes/api/whitelist/insertions.ts
+++ b/src/routes/api/whitelist/insertions.ts
@@ -48,15 +48,15 @@ type TimeCost = {
 };
 
 type Insertion = {
-	userChosen: TimeCost|undefined;
+	userChosen: TimeCost | undefined;
 	busStops: TimeCost[][];
 	both: TimeCost[][];
 	company: number;
 	vehicle: number;
-	tour1: number|undefined;
-	tour2: number|undefined;
-	event1: number|undefined;
-	event2: number|undefined;
+	tour1: number | undefined;
+	tour2: number | undefined;
+	event1: number | undefined;
+	event2: number | undefined;
 };
 
 export type InsertionDurations = {
@@ -90,7 +90,7 @@ export function evaluateInsertion(
 	startFixed: boolean
 ): TimeCost | undefined {
 	const fullDuration = durations.approach + durations.return + durations.pickupToDropoff;
-	console.log("window", window);
+	console.log('window', window);
 	console.log(fullDuration);
 	console.log(window.getDurationMs());
 	let arrivalWindow =
@@ -191,10 +191,10 @@ export function computeTravelDurations(
 	busStopTimes: Interval[][],
 	busStopCompanyFilter: boolean[][]
 ): Insertion[] {
-	let insertionCount=0;
+	let insertionCount = 0;
 	[...possibleInsertionsByVehicle].forEach(([v, ranges]) => {
-		ranges.forEach(range => {
-			insertionCount+=range.latestDropoff+1-range.earliestPickup;
+		ranges.forEach((range) => {
+			insertionCount += range.latestDropoff + 1 - range.earliestPickup;
 		});
 	});
 	const allInsertions = new Array<Insertion>(insertionCount);
@@ -233,12 +233,12 @@ export function computeTravelDurations(
 			if (prevTime < new Date(Date.now() + minutesToMs(MIN_PREP_MINUTES))) {
 				return;
 			}
-			if(allInsertions[insertionInfo.insertionIdx]==undefined){
+			if (allInsertions[insertionInfo.insertionIdx] == undefined) {
 				const busStops = new Array<TimeCost[]>(busStopTimes.length);
 				const both = new Array<TimeCost[]>(busStopTimes.length);
-				for(let i=0;i!=busStops.length;++i){
-					busStops[i]=new Array<TimeCost>(busStopTimes[i].length);
-					both[i]=new Array<TimeCost>(busStopTimes[i].length);
+				for (let i = 0; i != busStops.length; ++i) {
+					busStops[i] = new Array<TimeCost>(busStopTimes[i].length);
+					both[i] = new Array<TimeCost>(busStopTimes[i].length);
 				}
 				allInsertions[insertionInfo.insertionIdx] = {
 					userChosen: undefined,
@@ -246,11 +246,11 @@ export function computeTravelDurations(
 					both,
 					company: companies[insertionInfo.companyIdx].id,
 					vehicle: insertionInfo.vehicle.id,
-					tour1: prev==undefined?undefined:prev.tourId,
-					tour2: next==undefined?undefined:next.tourId,
-					event1: prev==undefined?undefined:prev.id,
-					event2: next==undefined?undefined:next.id
-				}
+					tour1: prev == undefined ? undefined : prev.tourId,
+					tour2: next == undefined ? undefined : next.tourId,
+					event1: prev == undefined ? undefined : prev.id,
+					event2: next == undefined ? undefined : next.id
+				};
 			}
 			const nextTime =
 				next == undefined
@@ -261,14 +261,22 @@ export function computeTravelDurations(
 			const fullWindowDuration = nextTime.getTime() - prevTime.getTime();
 			let window: Interval | undefined = new Interval(prevTime, nextTime);
 			console.log(insertionInfo.vehicle.events.length);
-			console.log("aa", insertionInfo.nextEventIdx);
-			console.log(next==undefined);
+			console.log('aa', insertionInfo.nextEventIdx);
+			console.log(next == undefined);
 			console.log(insertionInfo.insertionIdx);
 			console.log(insertionInfo.insertionIdx == insertionInfo.vehicle.events.length);
-			const toCompanyFromUserChosen = routingResults.userChosen.toCompany[insertionInfo.companyIdx].duration;
-			const fromCompanyToUserChosen = routingResults.userChosen.fromCompany[insertionInfo.companyIdx].duration;
-			const fromPrevToUserChosen = prev==undefined?0:routingResults.userChosen.fromPrevEvent[insertionInfo.prevEventIdx].duration;
-			const toNextFromUserChosen = next==undefined?0:routingResults.userChosen.toNextEvent[insertionInfo.nextEventIdx].duration;
+			const toCompanyFromUserChosen =
+				routingResults.userChosen.toCompany[insertionInfo.companyIdx].duration;
+			const fromCompanyToUserChosen =
+				routingResults.userChosen.fromCompany[insertionInfo.companyIdx].duration;
+			const fromPrevToUserChosen =
+				prev == undefined
+					? 0
+					: routingResults.userChosen.fromPrevEvent[insertionInfo.prevEventIdx].duration;
+			const toNextFromUserChosen =
+				next == undefined
+					? 0
+					: routingResults.userChosen.toNextEvent[insertionInfo.nextEventIdx].duration;
 			if (busStopIdx == undefined) {
 				// insert userChosen
 				if (type == (startFixed ? InsertionType.APPEND : InsertionType.PREPEND)) {
@@ -283,19 +291,15 @@ export function computeTravelDurations(
 					'Accessing nonexisting next event.'
 				);
 				const toInsert = startFixed ? ToInsert.DROPOFF : ToInsert.PICKUP;
-				const entryExists = allInsertions[insertionInfo.insertionIdx].userChosen!=undefined;
-				const approachDuration = comesFromCompany
-				? fromCompanyToUserChosen
-				: fromPrevToUserChosen;
-				const returnDuration = returnsToCompany
-				? toCompanyFromUserChosen
-				: toNextFromUserChosen;
+				const entryExists = allInsertions[insertionInfo.insertionIdx].userChosen != undefined;
+				const approachDuration = comesFromCompany ? fromCompanyToUserChosen : fromPrevToUserChosen;
+				const returnDuration = returnsToCompany ? toCompanyFromUserChosen : toNextFromUserChosen;
 				const cost = evaluateInsertion(
 					type,
 					window,
 					{
-						approach:approachDuration,
-						return:returnDuration,
+						approach: approachDuration,
+						return: returnDuration,
 						pickupToDropoff: 0,
 						toNext: next == undefined ? 0 : next.durationFromPrev,
 						fromPrev: prev == undefined ? 0 : prev.durationToNext,
@@ -306,7 +310,7 @@ export function computeTravelDurations(
 					undefined,
 					startFixed
 				);
-				console.log("cost", cost);
+				console.log('cost', cost);
 				if (cost == undefined) {
 					return;
 				}
@@ -342,34 +346,35 @@ export function computeTravelDurations(
 			const travelDuration = travelDurations[busStopIdx];
 			const times = busStopTimes[busStopIdx];
 			for (let timeIdx = 0; timeIdx != times.length; ++timeIdx) {
-				const fromCompanyToBus = busStopRoutingResult.fromCompany[insertionInfo.companyIdx].duration;
+				const fromCompanyToBus =
+					busStopRoutingResult.fromCompany[insertionInfo.companyIdx].duration;
 				const toCompanyFromBus = busStopRoutingResult.toCompany[insertionInfo.companyIdx].duration;
-				const fromPrevToBus = busStopRoutingResult.fromPrevEvent[insertionInfo.prevEventIdx].duration;
-				const toNextFromBus = routingResults.userChosen.toNextEvent[insertionInfo.nextEventIdx].duration;
+				const fromPrevToBus =
+					busStopRoutingResult.fromPrevEvent[insertionInfo.prevEventIdx].duration;
+				const toNextFromBus =
+					routingResults.userChosen.toNextEvent[insertionInfo.nextEventIdx].duration;
 				// insert userChosen coordinates and busstop
-				const approachDurationBoth = 
-				(startFixed
-					? comesFromCompany
-						? fromCompanyToBus
-						: fromPrevToBus
-					: returnsToCompany
-						? toCompanyFromUserChosen
-						: toNextFromUserChosen) +
-				travelDuration;
-				const returnDurationBoth = 
-				(startFixed
-					? returnsToCompany
-						? toCompanyFromUserChosen
-						: toNextFromUserChosen
-					: returnsToCompany
-						? toCompanyFromBus
-						: toNextFromBus) +
-				travelDuration;
+				const approachDurationBoth =
+					(startFixed
+						? comesFromCompany
+							? fromCompanyToBus
+							: fromPrevToBus
+						: returnsToCompany
+							? toCompanyFromUserChosen
+							: toNextFromUserChosen) + travelDuration;
+				const returnDurationBoth =
+					(startFixed
+						? returnsToCompany
+							? toCompanyFromUserChosen
+							: toNextFromUserChosen
+						: returnsToCompany
+							? toCompanyFromBus
+							: toNextFromBus) + travelDuration;
 				const timeCostBoth = evaluateInsertion(
 					type,
 					window,
 					{
-						approach:approachDurationBoth,
+						approach: approachDurationBoth,
 						return: returnDurationBoth,
 						pickupToDropoff: travelDuration,
 						toNext: next == undefined ? 0 : next.durationFromPrev,
@@ -384,20 +389,15 @@ export function computeTravelDurations(
 				if (timeCostBoth == undefined) {
 					continue;
 				}
-				allInsertions[insertionInfo.insertionIdx].both![busStopIdx][timeIdx] =
-					timeCostBoth;
+				allInsertions[insertionInfo.insertionIdx].both![busStopIdx][timeIdx] = timeCostBoth;
 
 				// insert busstop
 				if (type == (startFixed ? InsertionType.PREPEND : InsertionType.APPEND)) {
 					return;
 				}
 				const toInsert = startFixed ? ToInsert.PICKUP : ToInsert.DROPOFF;
-				const approachDuration = comesFromCompany
-				? fromCompanyToBus
-				: fromPrevToBus;
-				const returnDuration = returnsToCompany
-				? toCompanyFromBus
-				: toNextFromBus;
+				const approachDuration = comesFromCompany ? fromCompanyToBus : fromPrevToBus;
+				const returnDuration = returnsToCompany ? toCompanyFromBus : toNextFromBus;
 				const timeCostBus = evaluateInsertion(
 					type,
 					window,
@@ -415,8 +415,7 @@ export function computeTravelDurations(
 					startFixed
 				);
 				if (timeCostBus != undefined) {
-					allInsertions[insertionInfo.insertionIdx].busStops[busStopIdx][timeIdx] =
-						timeCostBus;
+					allInsertions[insertionInfo.insertionIdx].busStops[busStopIdx][timeIdx] = timeCostBus;
 				}
 			}
 		});

--- a/src/routes/api/whitelist/insertions.ts
+++ b/src/routes/api/whitelist/insertions.ts
@@ -264,6 +264,10 @@ export function computeTravelDurations(
 			console.log(next == undefined);
 			console.log(insertionInfo.insertionIdx);
 			console.log(insertionInfo.insertionIdx == insertionInfo.vehicle.events.length);
+			console.log("companyidx:",insertionInfo.companyIdxInRoutingResults);
+			console.log(companies.length);
+			console.log(routingResults.userChosen.toCompany[insertionInfo.companyIdxInRoutingResults]);
+			console.log(routingResults.userChosen.toCompany);
 			const toCompanyFromUserChosen =
 				routingResults.userChosen.toCompany[insertionInfo.companyIdxInRoutingResults].duration;
 			const fromCompanyToUserChosen =

--- a/src/routes/api/whitelist/insertions.ts
+++ b/src/routes/api/whitelist/insertions.ts
@@ -261,22 +261,22 @@ export function computeTravelDurations(
 			const fullWindowDuration = nextTime.getTime() - prevTime.getTime();
 			let window: Interval | undefined = new Interval(prevTime, nextTime);
 			console.log(insertionInfo.vehicle.events.length);
-			console.log('aa', insertionInfo.nextEventIdx);
+			console.log('aa', insertionInfo.nextEventIdxInRoutingResults);
 			console.log(next == undefined);
 			console.log(insertionInfo.insertionIdx);
 			console.log(insertionInfo.insertionIdx == insertionInfo.vehicle.events.length);
 			const toCompanyFromUserChosen =
-				routingResults.userChosen.toCompany[insertionInfo.companyIdx].duration;
+				routingResults.userChosen.toCompany[insertionInfo.companyIdxInRoutingResults].duration;
 			const fromCompanyToUserChosen =
-				routingResults.userChosen.fromCompany[insertionInfo.companyIdx].duration;
+				routingResults.userChosen.fromCompany[insertionInfo.companyIdxInRoutingResults].duration;
 			const fromPrevToUserChosen =
 				prev == undefined
 					? 0
-					: routingResults.userChosen.fromPrevEvent[insertionInfo.prevEventIdx].duration;
+					: routingResults.userChosen.fromPrevEvent[insertionInfo.prevEventIdxInRoutingResults].duration;
 			const toNextFromUserChosen =
 				next == undefined
 					? 0
-					: routingResults.userChosen.toNextEvent[insertionInfo.nextEventIdx].duration;
+					: routingResults.userChosen.toNextEvent[insertionInfo.nextEventIdxInRoutingResults].duration;
 			if (busStopIdx == undefined) {
 				// insert userChosen
 				if (type == (startFixed ? InsertionType.APPEND : InsertionType.PREPEND)) {
@@ -347,12 +347,12 @@ export function computeTravelDurations(
 			const times = busStopTimes[busStopIdx];
 			for (let timeIdx = 0; timeIdx != times.length; ++timeIdx) {
 				const fromCompanyToBus =
-					busStopRoutingResult.fromCompany[insertionInfo.companyIdx].duration;
-				const toCompanyFromBus = busStopRoutingResult.toCompany[insertionInfo.companyIdx].duration;
+					busStopRoutingResult.fromCompany[insertionInfo.companyIdxInRoutingResults].duration;
+				const toCompanyFromBus = busStopRoutingResult.toCompany[insertionInfo.companyIdxInRoutingResults].duration;
 				const fromPrevToBus =
-					busStopRoutingResult.fromPrevEvent[insertionInfo.prevEventIdx].duration;
+					busStopRoutingResult.fromPrevEvent[insertionInfo.prevEventIdxInRoutingResults].duration;
 				const toNextFromBus =
-					routingResults.userChosen.toNextEvent[insertionInfo.nextEventIdx].duration;
+					routingResults.userChosen.toNextEvent[insertionInfo.nextEventIdxInRoutingResults].duration;
 				// insert userChosen coordinates and busstop
 				const approachDurationBoth =
 					(startFixed

--- a/src/routes/api/whitelist/insertions.ts
+++ b/src/routes/api/whitelist/insertions.ts
@@ -12,14 +12,14 @@ import {
 	TAXI_WAITING_TIME_COST_FACTOR
 } from '$lib/constants';
 
-enum InsertionType {
+export enum InsertionType {
 	CONNECT,
 	APPEND,
 	PREPEND,
 	INSERT
 }
 
-enum ToInsert {
+export enum ToInsert {
 	PICKUP,
 	DROPOFF,
 	BOTH
@@ -58,7 +58,7 @@ type Insertion = {
 	event2: number;
 };
 
-type InsertionDurations = {
+export type InsertionDurations = {
 	approach: number;
 	return: number;
 	pickupToDropoff: number;

--- a/src/routes/api/whitelist/insertions.ts
+++ b/src/routes/api/whitelist/insertions.ts
@@ -1,0 +1,379 @@
+import type { Company, Event } from '$lib/compositionTypes';
+import { Interval } from '$lib/interval';
+import { ITERATE_INSERTIONS_MODE, iterateAllInsertions } from './utils';
+import { type RoutingResults } from './routing';
+import type { Range } from './capacitySimulation';
+import { minutesToMs } from '$lib/time_utils';
+import {
+	MIN_PREP_MINUTES,
+	PASSENGER_CHANGE_TIME,
+	PASSENGER_TIME_COST_FACTOR,
+	TAXI_DRIVING_TIME_COST_FACTOR,
+	TAXI_WAITING_TIME_COST_FACTOR
+} from '$lib/constants';
+
+enum InsertionType {
+	CONNECT,
+	APPEND,
+	PREPEND,
+	INSERT
+}
+
+enum ToInsert {
+	PICKUP,
+	DROPOFF,
+	BOTH
+}
+
+const cases = [
+	InsertionType.CONNECT,
+	InsertionType.APPEND,
+	InsertionType.PREPEND,
+	InsertionType.INSERT
+];
+
+type Cost = {
+	taxiWaitingTime: number;
+	taxiDrivingDuration: number;
+	passengerDuration: number;
+	total: number;
+};
+
+type TimeCost = {
+	time: Date;
+	cost: Cost;
+};
+
+type Insertion = {
+	userChosen: TimeCost;
+	busStops: TimeCost[][];
+	both: TimeCost[][];
+	approachDuration: number | undefined;
+	returnDuration: number | undefined;
+	company: number;
+	vehicle: number;
+	tour1: number;
+	tour2: number;
+	event1: number;
+	event2: number;
+};
+
+type InsertionDurations = {
+	approach: number;
+	return: number;
+	pickupToDropoff: number;
+	fromPrev: number;
+	toNext: number;
+	fullWindow: number;
+};
+
+export function costFn(
+	taxiDrivingDuration: number,
+	taxiWaitingTime: number,
+	passengerDuration: number
+) {
+	return (
+		TAXI_DRIVING_TIME_COST_FACTOR * taxiDrivingDuration +
+		PASSENGER_TIME_COST_FACTOR * passengerDuration +
+		TAXI_WAITING_TIME_COST_FACTOR * taxiWaitingTime
+	);
+}
+
+export function evaluateInsertion(
+	type: InsertionType,
+	window: Interval,
+	durations: InsertionDurations,
+	toInsert: ToInsert,
+	currentBest: TimeCost | undefined,
+	busStopWindow: Interval | undefined,
+	startFixed: boolean
+): TimeCost | undefined {
+	const fullDuration = durations.approach + durations.return + durations.pickupToDropoff;
+	let arrivalWindow =
+		window.getDurationMs() < fullDuration
+			? undefined
+			: window.shrink(durations.approach, durations.return);
+	if (busStopWindow != undefined) {
+		arrivalWindow = arrivalWindow?.intersect(busStopWindow);
+	}
+	if (arrivalWindow == undefined) {
+		return undefined;
+	}
+	const cost = computeCosts(type, durations, toInsert);
+	if (currentBest == undefined || currentBest.cost.total <= cost.total) {
+		return undefined;
+	}
+	return {
+		time: startFixed ? arrivalWindow.startTime : arrivalWindow.endTime,
+		cost
+	};
+}
+
+export function computeCosts(
+	type: InsertionType,
+	durations: InsertionDurations,
+	toInsert: ToInsert
+): Cost {
+	const taxiDrivingDuration =
+		durations.approach +
+		durations.return +
+		(toInsert == ToInsert.BOTH ? durations.pickupToDropoff : 0);
+	const taxiDrivingDurationRelative =
+		taxiDrivingDuration -
+		(function () {
+			switch (type) {
+				case InsertionType.APPEND:
+					return durations.fromPrev;
+				case InsertionType.PREPEND:
+					return durations.toNext;
+				case InsertionType.CONNECT:
+					return durations.toNext + durations.fromPrev;
+				case InsertionType.INSERT:
+					return durations.toNext + durations.fromPrev;
+			}
+		})();
+	const taxiWaitingTime =
+		type == InsertionType.CONNECT || type == InsertionType.INSERT
+			? durations.fullWindow - taxiDrivingDuration - PASSENGER_CHANGE_TIME - toInsert ==
+				ToInsert.BOTH
+				? PASSENGER_CHANGE_TIME
+				: 0
+			: 0;
+	const passengerDuration = (function () {
+		switch (toInsert) {
+			case ToInsert.PICKUP:
+				console.assert(type != InsertionType.APPEND, 'Trying to Append a Pickup event.');
+				return durations.return;
+			case ToInsert.DROPOFF:
+				console.assert(type != InsertionType.PREPEND, 'Trying to Prepend a Dropoff event.');
+				return durations.approach;
+			case ToInsert.BOTH:
+				return durations.pickupToDropoff;
+		}
+	})();
+	const total = costFn(taxiDrivingDuration, taxiWaitingTime, passengerDuration);
+	return {
+		taxiDrivingDuration: taxiDrivingDurationRelative,
+		taxiWaitingTime,
+		passengerDuration,
+		total
+	};
+}
+
+export function getBestTime(
+	approachDuration: number,
+	returnDuration: number,
+	window: Interval,
+	busStopTime: Interval,
+	startFixed: boolean
+): Date | undefined {
+	let arrivalWindow =
+		window.getDurationMs() < approachDuration + returnDuration
+			? undefined
+			: window.shrink(approachDuration, returnDuration);
+	arrivalWindow = arrivalWindow?.intersect(busStopTime);
+	return startFixed ? arrivalWindow?.startTime : arrivalWindow?.endTime;
+}
+
+export function computeTravelDurations(
+	companies: Company[],
+	possibleInsertionsByVehicle: Map<number, Range[]>,
+	routingResults: RoutingResults,
+	travelDurations: number[],
+	startFixed: boolean,
+	busStopTimes: Interval[][],
+	busStopCompanyFilter: boolean[][]
+): Insertion[][] {
+	const allInsertions = new Array<Insertion[]>();
+	iterateAllInsertions(
+		ITERATE_INSERTIONS_MODE.SINGLE,
+		companies,
+		busStopCompanyFilter,
+		possibleInsertionsByVehicle,
+		(busStopIdx, companyIdx, prevEventIdx, nextEventIdx, vehicle, insertionIdx, _) => {
+			if (prevEventIdx == undefined) {
+				return;
+			}
+			if (nextEventIdx == undefined) {
+				return;
+			}
+			const prev: Event | undefined =
+				insertionIdx == 0 ? undefined : vehicle.events[insertionIdx - 1];
+			const next: Event | undefined =
+				insertionIdx == vehicle.events.length ? undefined : vehicle.events[insertionIdx];
+			cases.forEach((type) => {
+				if (type == (startFixed ? InsertionType.APPEND : InsertionType.PREPEND)) {
+					return;
+				}
+				if (
+					prev == undefined ||
+					next == undefined ||
+					(prev.tourId == next.tourId) != (type == InsertionType.INSERT)
+				) {
+					return;
+				}
+				const returnsToCompany = type === InsertionType.CONNECT || type === InsertionType.APPEND;
+				const comesFromCompany = type === InsertionType.CONNECT || type === InsertionType.PREPEND;
+
+				const prevTime = comesFromCompany ? prev.arrival : prev.communicated;
+				if (prevTime < new Date(Date.now() + minutesToMs(MIN_PREP_MINUTES))) {
+					return;
+				}
+				const nextTime = returnsToCompany ? next.departure : next.communicated;
+				const fullWindowDuration = nextTime.getTime() - prevTime.getTime();
+				let window: Interval | undefined = new Interval(prevTime, nextTime);
+				if (busStopIdx == undefined) {
+					// insert userChosen
+					if (type == (startFixed ? InsertionType.PREPEND : InsertionType.APPEND)) {
+						return;
+					}
+					const approachDuration = comesFromCompany
+						? routingResults.userChosen.fromCompany[companyIdx].duration
+						: routingResults.userChosen.fromPrevEvent[prevEventIdx].duration;
+					const returnDuration = returnsToCompany
+						? routingResults.userChosen.toCompany[companyIdx].duration
+						: routingResults.userChosen.toNextEvent[nextEventIdx].duration;
+					const toInsert = startFixed ? ToInsert.DROPOFF : ToInsert.PICKUP;
+					const cost = evaluateInsertion(
+						type,
+						window,
+						{
+							approach: approachDuration,
+							return: returnDuration,
+							pickupToDropoff: 0,
+							toNext: next.durationFromPrev,
+							fromPrev: prev.durationToNext,
+							fullWindow: fullWindowDuration
+						},
+						toInsert,
+						allInsertions[insertionIdx][toInsert].userChosen,
+						undefined,
+						startFixed
+					);
+					if (cost == undefined) {
+						return;
+					}
+					allInsertions[insertionIdx][toInsert].userChosen = cost;
+					return;
+				}
+				const relevantAvailabilities = (function () {
+					switch (type) {
+						case InsertionType.APPEND:
+							return vehicle.availabilities.filter((availability) => availability.covers(prevTime));
+						case InsertionType.PREPEND:
+							return vehicle.availabilities.filter((availability) => availability.covers(nextTime));
+						case InsertionType.CONNECT:
+							return vehicle.availabilities.filter((availability) =>
+								availability.contains(new Interval(prevTime, nextTime))
+							);
+						case InsertionType.INSERT:
+							console.assert(false, 'unexpected InsertionType in computeTravelDurations');
+					}
+				})();
+
+				console.assert(
+					relevantAvailabilities != undefined && relevantAvailabilities.length < 2,
+					'Unexpectedly found 2 intervals, which are supposed to be disjoint, containing the same timestamp.'
+				);
+				if (relevantAvailabilities == undefined || relevantAvailabilities.length == 0) {
+					return;
+				}
+				const relevantAvailability = relevantAvailabilities[0];
+				window = window.intersect(relevantAvailability);
+				if (window == undefined) {
+					return;
+				}
+				const busStopRoutingResult = routingResults.busStops[busStopIdx];
+				const travelDuration = travelDurations[busStopIdx];
+				const times = busStopTimes[busStopIdx];
+				for (let timeIdx = 0; timeIdx != times.length; ++timeIdx) {
+					// insert busstop
+					const approachDuration = comesFromCompany
+						? busStopRoutingResult.fromCompany[companyIdx].duration
+						: busStopRoutingResult.fromPrevEvent[prevEventIdx].duration;
+					const returnDuration = returnsToCompany
+						? busStopRoutingResult.toCompany[companyIdx].duration
+						: busStopRoutingResult.toNextEvent[nextEventIdx].duration;
+					const bestTime = getBestTime(
+						approachDuration,
+						returnDuration,
+						window,
+						times[timeIdx],
+						startFixed
+					);
+					if (bestTime != undefined) {
+						const toInsert = startFixed ? ToInsert.PICKUP : ToInsert.DROPOFF;
+						const timeCost = evaluateInsertion(
+							type,
+							window,
+							{
+								approach: approachDuration,
+								return: returnDuration,
+								pickupToDropoff: travelDuration,
+								toNext: next.durationFromPrev,
+								fromPrev: prev.durationToNext,
+								fullWindow: fullWindowDuration
+							},
+							toInsert,
+							allInsertions[insertionIdx][toInsert].both[busStopIdx][timeIdx],
+							times[timeIdx],
+							startFixed
+						);
+						if (timeCost != undefined) {
+							allInsertions[insertionIdx][toInsert].busStops[busStopIdx][timeIdx] = timeCost;
+						}
+					}
+
+					// insert userChosen coordinates and busstop
+					const approachDurationBoth =
+						(startFixed
+							? comesFromCompany
+								? busStopRoutingResult.fromCompany[companyIdx].duration
+								: busStopRoutingResult.fromPrevEvent[prevEventIdx].duration
+							: comesFromCompany
+								? routingResults.userChosen.fromCompany[companyIdx].duration
+								: routingResults.userChosen.fromPrevEvent[prevEventIdx].duration) + travelDuration;
+					const returnDurationBoth =
+						(startFixed
+							? returnsToCompany
+								? routingResults.userChosen.toCompany[nextEventIdx].duration
+								: routingResults.userChosen.toNextEvent[nextEventIdx].duration
+							: returnsToCompany
+								? busStopRoutingResult.toCompany[companyIdx].duration
+								: busStopRoutingResult.toNextEvent[nextEventIdx].duration) + travelDuration;
+					const bestTimeBoth = getBestTime(
+						approachDurationBoth,
+						returnDurationBoth,
+						window,
+						times[timeIdx],
+						startFixed
+					);
+					if (bestTimeBoth == undefined) {
+						continue;
+					}
+					const timeCost = evaluateInsertion(
+						type,
+						window,
+						{
+							approach: approachDurationBoth,
+							return: returnDurationBoth,
+							pickupToDropoff: travelDuration,
+							toNext: next.durationFromPrev,
+							fromPrev: prev.durationToNext,
+							fullWindow: fullWindowDuration
+						},
+						ToInsert.BOTH,
+						allInsertions[insertionIdx][ToInsert.BOTH].both[busStopIdx][timeIdx],
+						times[timeIdx],
+						startFixed
+					);
+					if (timeCost == undefined) {
+						continue;
+					}
+					allInsertions[insertionIdx][ToInsert.BOTH].both[busStopIdx][timeIdx] = timeCost;
+				}
+			});
+		}
+	);
+	return allInsertions;
+}

--- a/src/routes/api/whitelist/routing.ts
+++ b/src/routes/api/whitelist/routing.ts
@@ -54,16 +54,16 @@ export function gatherRoutingCoordinates(
 		companies,
 		busStopCompanyFilter,
 		insertionsByVehicle,
-		(busStopIdx, companyIdx, prevEventPos_, nextEventPos_, vehicle, insertionIdx) => {
+		(busStopIdx, insertionInfo) => {
 			const backwardMany =
 				busStopIdx == undefined ? userChosenBackwardMany : busStopBackwardMany[busStopIdx];
 			const forwardMany =
 				busStopIdx == undefined ? userChosenForwardMany : busStopForwardMany[busStopIdx];
-			if (insertionIdx != 0) {
-				backwardMany.push(vehicle.events[insertionIdx - 1].coordinates);
+			if (insertionInfo.insertionIdx != 0) {
+				backwardMany.push(insertionInfo.vehicle.events[insertionInfo.insertionIdx - 1].coordinates);
 			}
-			if (insertionIdx != vehicle.events.length) {
-				forwardMany.push(vehicle.events[insertionIdx].coordinates);
+			if (insertionInfo.insertionIdx != insertionInfo.vehicle.events.length) {
+				forwardMany.push(insertionInfo.vehicle.events[insertionInfo.insertionIdx].coordinates);
 			}
 		}
 	);

--- a/src/routes/api/whitelist/routing.ts
+++ b/src/routes/api/whitelist/routing.ts
@@ -1,0 +1,117 @@
+import { Direction, oneToMany, type OneToManyResult } from '$lib/api';
+import type { BusStop } from '$lib/busStop';
+import type { Company } from '$lib/compositionTypes';
+import { Coordinates } from '$lib/location';
+import type { Range } from './capacitySimulation';
+import { iterateAllInsertions, ITERATE_INSERTIONS_MODE } from './utils';
+
+export type InsertionRoutingResult = {
+	fromCompany: OneToManyResult[];
+	toCompany: OneToManyResult[];
+	fromPrevEvent: OneToManyResult[];
+	toNextEvent: OneToManyResult[];
+};
+
+export type RoutingResults = {
+	busStops: InsertionRoutingResult[];
+	userChosen: InsertionRoutingResult;
+};
+
+type RoutingCoordinates = {
+	busStopForwardMany: Coordinates[][];
+	busStopBackwardMany: Coordinates[][];
+	userChosenForwardMany: Coordinates[];
+	userChosenBackwardMany: Coordinates[];
+};
+
+export function gatherRoutingCoordinates(
+	companies: Company[],
+	busStops: BusStop[],
+	insertionsByVehicle: Map<number, Range[]>,
+	busStopCompanyFilter: boolean[][]
+): RoutingCoordinates {
+	const userChosenForwardMany = new Array<Coordinates>();
+	const userChosenBackwardMany = new Array<Coordinates>();
+	const busStopForwardMany = new Array<Coordinates[]>(busStops.length);
+	const busStopBackwardMany = new Array<Coordinates[]>(busStops.length);
+	for (let busStopIdx = 0; busStopIdx != busStops.length; ++busStopIdx) {
+		busStopForwardMany[busStopIdx] = new Array<Coordinates>();
+		busStopBackwardMany[busStopIdx] = new Array<Coordinates>();
+	}
+	companies.forEach((company, companyIdx) => {
+		for (let busStopIdx = 0; busStopIdx != busStops.length; ++busStopIdx) {
+			if (!busStopCompanyFilter[busStopIdx][companyIdx]) {
+				continue;
+			}
+			busStopForwardMany[busStopIdx].push(company.coordinates);
+			busStopBackwardMany[busStopIdx].push(company.coordinates);
+		}
+		userChosenForwardMany.push(company.coordinates);
+		userChosenBackwardMany.push(company.coordinates);
+	});
+	iterateAllInsertions(
+		ITERATE_INSERTIONS_MODE.SINGLE,
+		companies,
+		busStopCompanyFilter,
+		insertionsByVehicle,
+		(busStopIdx, companyIdx, prevEventPos_, nextEventPos_, vehicle, insertionIdx) => {
+			const backwardMany =
+				busStopIdx == undefined ? userChosenBackwardMany : busStopBackwardMany[busStopIdx];
+			const forwardMany =
+				busStopIdx == undefined ? userChosenForwardMany : busStopForwardMany[busStopIdx];
+			if (insertionIdx != 0) {
+				backwardMany.push(vehicle.events[insertionIdx - 1].coordinates);
+			}
+			if (insertionIdx != vehicle.events.length) {
+				forwardMany.push(vehicle.events[insertionIdx].coordinates);
+			}
+		}
+	);
+	return {
+		busStopForwardMany,
+		busStopBackwardMany,
+		userChosenForwardMany,
+		userChosenBackwardMany
+	};
+}
+
+export async function routing(
+	coordinates: RoutingCoordinates,
+	userChosen: Coordinates,
+	busStops: BusStop[],
+	busStopCompanyFilter: boolean[][]
+): Promise<RoutingResults> {
+	console.assert(busStopCompanyFilter.length != 0);
+	const from = await oneToMany(userChosen, coordinates.userChosenBackwardMany, Direction.Backward);
+	const to = await oneToMany(userChosen, coordinates.userChosenForwardMany, Direction.Forward);
+	const ret = {
+		userChosen: {
+			fromCompany: from.slice(0, busStopCompanyFilter.length),
+			fromPrevEvent: from.slice(busStopCompanyFilter.length),
+			toCompany: to.slice(0, busStopCompanyFilter.length),
+			toNextEvent: to.slice(busStopCompanyFilter.length)
+		},
+		busStops: new Array<InsertionRoutingResult>(busStops.length)
+	};
+	for (let busStopIdx = 0; busStopIdx != busStops.length; ++busStopIdx) {
+		const busStop = busStops[busStopIdx];
+		const relevantCompanyCount = busStopCompanyFilter[busStopIdx].filter((f) => f).length;
+		const from = await oneToMany(
+			busStop.coordinates,
+			coordinates.busStopBackwardMany[busStopIdx],
+			Direction.Backward
+		);
+		const to = await oneToMany(
+			busStop.coordinates,
+			coordinates.busStopForwardMany[busStopIdx],
+			Direction.Forward
+		);
+		ret.busStops[busStopIdx] = {
+			fromCompany: from.slice(0, relevantCompanyCount),
+			fromPrevEvent: from.slice(relevantCompanyCount),
+			toCompany: to.slice(0, relevantCompanyCount),
+			toNextEvent: to.slice(relevantCompanyCount)
+		};
+	}
+	return ret;
+}

--- a/src/routes/api/whitelist/utils.ts
+++ b/src/routes/api/whitelist/utils.ts
@@ -61,10 +61,10 @@ export function iterateAllInsertions(
 						if (outerIdx != vehicle.events.length) {
 							nextEventIdxInRoutingResults++;
 						}
-						companyIdxInRoutingResults++;
 					}
 				});
 			});
+			companyIdxInRoutingResults++;
 		});
 	};
 	iterateInsertions(undefined, undefined);

--- a/src/routes/api/whitelist/utils.ts
+++ b/src/routes/api/whitelist/utils.ts
@@ -22,13 +22,14 @@ export function iterateAllInsertions(
 		companyFilter: boolean[] | undefined,
 		busStopIdx: number | undefined
 	) => {
-		let prevEventIdx = 0;
-		let nextEventIdx = 0;
+		let prevEventIdxInRoutingResults = 0;
+		let nextEventIdxInRoutingResults = 0;
+		let companyIdxInRoutingResults = 0;
 		companies.forEach((company, companyIdx) => {
 			if (companyFilter != undefined && !companyFilter[companyIdx]) {
 				return;
 			}
-			company.vehicles.forEach((vehicle, vid) => {
+			company.vehicles.forEach((vehicle) => {
 				insertions.get(vehicle.id)!.forEach((insertion) => {
 					for (
 						let outerIdx = insertion.earliestPickup;
@@ -39,8 +40,9 @@ export function iterateAllInsertions(
 							insertionIdx: outerIdx,
 							companyIdx,
 							vehicle,
-							prevEventIdx,
-							nextEventIdx
+							prevEventIdxInRoutingResults,
+							nextEventIdxInRoutingResults,
+							companyIdxInRoutingResults
 						};
 						if (type == ITERATE_INSERTIONS_MODE.SINGLE) {
 							insertionFn(busStopIdx, info, undefined);
@@ -54,11 +56,12 @@ export function iterateAllInsertions(
 							}
 						}
 						if (outerIdx != 0) {
-							prevEventIdx++;
+							prevEventIdxInRoutingResults++;
 						}
 						if (outerIdx != vehicle.events.length) {
-							nextEventIdx++;
+							nextEventIdxInRoutingResults++;
 						}
+						companyIdxInRoutingResults++;
 					}
 				});
 			});
@@ -66,7 +69,6 @@ export function iterateAllInsertions(
 	};
 	iterateInsertions(undefined, undefined);
 	busStopCompanyFilter.forEach((companyFilter, busStopIdx) => {
-		const companyCount = companyFilter.filter((f) => f).length;
 		iterateInsertions(companyFilter, busStopIdx);
 	});
 }

--- a/src/routes/api/whitelist/utils.ts
+++ b/src/routes/api/whitelist/utils.ts
@@ -22,8 +22,8 @@ export function iterateAllInsertions(
 		companyFilter: boolean[] | undefined,
 		busStopIdx: number | undefined
 	) => {
-		let prevEventIdx=0;
-		let nextEventIdx=0;
+		let prevEventIdx = 0;
+		let nextEventIdx = 0;
 		companies.forEach((company, companyIdx) => {
 			if (companyFilter != undefined && !companyFilter[companyIdx]) {
 				return;

--- a/src/routes/api/whitelist/utils.ts
+++ b/src/routes/api/whitelist/utils.ts
@@ -1,0 +1,95 @@
+import type { Company, Vehicle } from '$lib/compositionTypes';
+import type { Range } from './capacitySimulation';
+
+export enum ITERATE_INSERTIONS_MODE {
+	SINGLE,
+	PAIRS
+}
+
+export function iterateAllInsertions(
+	type: ITERATE_INSERTIONS_MODE,
+	companies: Company[],
+	busStopCompanyFilter: boolean[][],
+	insertions: Map<number, Range[]>,
+	insertionFn: (
+		busStopIdx: number | undefined,
+		companyIdx: number,
+		prevEventPos: number | undefined,
+		nextEventPos: number | undefined,
+		vehicle: Vehicle,
+		outerInsertionIdx: number,
+		innerInsertionIdx: number | undefined
+	) => void
+) {
+	const iterateInsertions = (
+		companyFilter: boolean[] | undefined,
+		busStopIdx: number | undefined,
+		prevEventPos: number,
+		nextEventPos: number
+	) => {
+		companies.forEach((company, companyIdx) => {
+			if (companyFilter != undefined && !companyFilter[companyIdx]) {
+				return;
+			}
+			console.log('company', companyIdx);
+			company.vehicles.forEach((vehicle, vid) => {
+				console.log('vehicle', vid);
+				insertions.get(vehicle.id)!.forEach((insertion) => {
+					for (
+						let outerIdx = insertion.earliestPickup;
+						outerIdx != insertion.latestDropoff;
+						++outerIdx
+					) {
+						//console.log('insertion', outerIdx);
+						//console.log('nnext', nextEventPos);
+						if (type == ITERATE_INSERTIONS_MODE.SINGLE) {
+							insertionFn(
+								busStopIdx,
+								companyIdx,
+								outerIdx == 0 ? undefined : prevEventPos,
+								outerIdx == vehicle.events.length ? undefined : nextEventPos,
+								vehicle,
+								outerIdx,
+								undefined
+							);
+						} else {
+							for (
+								let innerIdx = outerIdx + 1;
+								innerIdx != insertion.latestDropoff + 1;
+								++innerIdx
+							) {
+								insertionFn(
+									busStopIdx,
+									companyIdx,
+									outerIdx == 0 ? undefined : prevEventPos,
+									outerIdx == vehicle.events.length ? undefined : nextEventPos,
+									vehicle,
+									outerIdx,
+									innerIdx
+								);
+							}
+						}
+						console.log('outer', outerIdx);
+						if (outerIdx != 0) {
+							prevEventPos++;
+						}
+						if (outerIdx != vehicle.events.length) {
+							nextEventPos++;
+						}
+					}
+				});
+			});
+		});
+	};
+	let prevEventPos = companies.length;
+	let nextEventPos = companies.length;
+	iterateInsertions(undefined, undefined, prevEventPos, nextEventPos);
+	busStopCompanyFilter.forEach((companyFilter, busStopIdx) => {
+		console.log('busstop', busStopIdx);
+		console.assert(companyFilter.length == companies.length);
+		const companyCount = companyFilter.filter((f) => f).length;
+		prevEventPos = companyCount;
+		nextEventPos = companyCount;
+		iterateInsertions(companyFilter, busStopIdx, prevEventPos, nextEventPos);
+	});
+}


### PR DESCRIPTION
For every request a pickup and a dropoff event must be either put into a new tour or inserted between two existing events.
This Pull-Request enables checking for every such slot between two consecutive events of the same vehicle, whether
it is possible to insert the dropoff, pickup and/or both at this slot.
It also assigns to each slot, costs for the duration the passenger would spent in the taxi as well as the change in taxi driving duration and taxi waiting time for the chosen vehicle compared to the current state.