### PR TITLE
Fix Null appearing in Blacklist Response

### DIFF
--- a/src/lib/server/booking/insertion.ts
+++ b/src/lib/server/booking/insertion.ts
@@ -62,6 +62,18 @@ export type NeighbourIds = {
 	nextDropoff: number | undefined;
 };
 
+export function toInsertionWithISOStrings(i: Insertion | undefined) {
+	return i === undefined
+		? undefined
+		: {
+				...i,
+				pickupTime: new Date(i.pickupTime).toISOString(),
+				dropoffTime: new Date(i.dropoffTime).toISOString(),
+				departure: i.departure == undefined ? undefined : new Date(i.departure).toISOString(),
+				arrival: i.arrival == undefined ? undefined : new Date(i.arrival).toISOString()
+			};
+}
+
 export function printInsertionEvaluation(e: Insertion) {
 	return (
 		'pickupTime: ' +

--- a/src/lib/testHelpers.ts
+++ b/src/lib/testHelpers.ts
@@ -4,6 +4,7 @@ import type { Coordinates } from '$lib/util/Coordinates';
 import type { UnixtimeMs } from '$lib/util/UnixtimeMs';
 import type { Capacities } from '$lib/server/booking/Capacities';
 import { db } from '$lib/server/db';
+import type { BusStop } from './server/booking/BusStop';
 
 export enum Zone {
 	NIESKY = 1,
@@ -183,3 +184,26 @@ export const selectEvents = async () => {
 		])
 		.execute();
 };
+
+export function assertArraySizes<T>(
+	response: T[][],
+	request: BusStop[],
+	caller: string,
+	checkForUndefined: boolean
+): void {
+	console.assert(response.length === request.length, 'Array size mismatch in ' + caller);
+	for (let i = 0; i != response.length; ++i) {
+		console.assert(
+			response[i].length === request[i].times.length,
+			'Array size mismatch in ' + caller
+		);
+		if (checkForUndefined) {
+			for (let j = 0; j != response[i].length; ++j) {
+				console.assert(
+					response[i][j] != null && response[i][j] != undefined,
+					'Undefined in ' + caller
+				);
+			}
+		}
+	}
+}

--- a/src/routes/api/blacklist/+server.ts
+++ b/src/routes/api/blacklist/+server.ts
@@ -2,9 +2,14 @@ import { Validator } from 'jsonschema';
 import { getViableBusStops, type BlacklistingResult } from './viableBusStops';
 import type { RequestEvent } from './$types';
 import { json } from '@sveltejs/kit';
-import { schemaDefinitions, whitelistSchema } from '../whitelist/WhitelistRequest';
+import {
+	schemaDefinitions,
+	toWhitelistRequestWithISOStrings,
+	whitelistSchema
+} from '../whitelist/WhitelistRequest';
 import { type WhitelistRequest as BlacklistRequest } from '../whitelist/WhitelistRequest';
 import type { BusStop } from '$lib/server/booking/BusStop';
+import { assertArraySizes } from '$lib/testHelpers';
 
 export const POST = async (event: RequestEvent) => {
 	// Validate parameters.
@@ -15,6 +20,11 @@ export const POST = async (event: RequestEvent) => {
 	if (!result.valid) {
 		return json({ message: result.errors }, { status: 400 });
 	}
+
+	console.log(
+		'BLACKLIST PARAMS: ',
+		JSON.stringify(toWhitelistRequestWithISOStrings(parameters), null, '\t')
+	);
 
 	// Add direct lookup to either start or target.
 	const directAsBusStop = {
@@ -50,6 +60,9 @@ export const POST = async (event: RequestEvent) => {
 	let startResponse = createResponse(start, parameters.startBusStops);
 	let targetResponse = createResponse(target, parameters.targetBusStops);
 
+	assertArraySizes(targetResponse, parameters.targetBusStops, 'Blacklist', true);
+	assertArraySizes(startResponse, parameters.startBusStops, 'Blacklist', true);
+
 	// Extract direct response.
 	const directResponse = parameters.startFixed
 		? targetResponse[targetResponse.length - 1]
@@ -60,6 +73,17 @@ export const POST = async (event: RequestEvent) => {
 		startResponse = startResponse.slice(0, startResponse.length - 1);
 	}
 
-	console.log({ startResponse, targetResponse, directResponse });
+	console.assert(
+		directResponse.length === parameters.directTimes.length,
+		'Array size mismatch in Blacklist - direct.'
+	);
+	for (let i = 0; i != directResponse.length; ++i) {
+		console.assert(
+			directResponse[i] != null && directResponse[i] != undefined,
+			'Undefined in Blacklist Response. - direct'
+		);
+	}
+
+	console.log('BLACKLIST RESPONSE: ', { startResponse, targetResponse, directResponse });
 	return json({ start: startResponse, target: targetResponse, direct: directResponse });
 };

--- a/src/routes/api/blacklist/viableBusStops.ts
+++ b/src/routes/api/blacklist/viableBusStops.ts
@@ -205,10 +205,7 @@ export const getViableBusStops = async (
 			createBatchQuery(
 				userChosen,
 				busStops.slice(currentPos, Math.min(currentPos + batchSize, busStops.length)),
-				busStopIntervals.slice(
-					currentPos,
-					Math.min(currentPos + batchSize, busStops.length)
-				),
+				busStopIntervals.slice(currentPos, Math.min(currentPos + batchSize, busStops.length)),
 				capacities
 			)
 		);

--- a/src/routes/api/blacklist/viableBusStops.ts
+++ b/src/routes/api/blacklist/viableBusStops.ts
@@ -50,10 +50,10 @@ const withBusStops = (busStops: BusStop[], busStopIntervals: Interval[][]) => {
 			const busStopIntervalSelect: RawBuilder<string>[] = busStopIntervals.flatMap((busStop, i) =>
 				busStop.map((t, j) => {
 					return sql<string>`SELECT
-                    cast(${i} as INTEGER) AS bus_stop_index,
-                    cast(${j} as INTEGER) AS time_index,
-                    cast(${t.startTime} as BIGINT) AS start_time,
-                    cast(${t.endTime} as BIGINT) AS end_time`;
+					 cast(${i} as INTEGER) AS bus_stop_index,
+					 cast(${j} as INTEGER) AS time_index,
+					 cast(${t.startTime} as BIGINT) AS start_time,
+					 cast(${t.endTime} as BIGINT) AS end_time`;
 				})
 			);
 			return db
@@ -205,20 +205,23 @@ export const getViableBusStops = async (
 			createBatchQuery(
 				userChosen,
 				busStops.slice(currentPos, Math.min(currentPos + batchSize, busStops.length)),
-				busStopIntervals,
+				busStopIntervals.slice(
+					currentPos,
+					Math.min(currentPos + batchSize, busStops.length)
+				),
 				capacities
 			)
 		);
 		currentPos += batchSize;
 	}
 	const batchResponses = await Promise.all(batches);
-	console.log(batchResponses);
-	return batchResponses.flatMap((batchResponse, idx) =>
+	const response = batchResponses.flatMap((batchResponse, idx) =>
 		batchResponse.map((r) => {
-			console.log(r);
 			return { timeIndex: r.timeIndex, busStopIndex: r.busStopIndex + idx * batchSize };
 		})
 	);
+	console.log('BLACKLIST QUERY RESULT: ', JSON.stringify(response, null, '\t'));
+	return response;
 };
 
 export type BlacklistingResult = {

--- a/src/routes/api/whitelist/+server.ts
+++ b/src/routes/api/whitelist/+server.ts
@@ -8,7 +8,8 @@ import {
 	whitelistSchema,
 	type WhitelistRequest
 } from './WhitelistRequest';
-import type { Insertion } from '$lib/server/booking/insertion';
+import { toInsertionWithISOStrings, type Insertion } from '$lib/server/booking/insertion';
+import { assertArraySizes } from '$lib/testHelpers';
 
 export type WhitelistResponse = {
 	start: (Insertion | undefined)[][];
@@ -47,6 +48,10 @@ export async function POST(event: RequestEvent) {
 		whitelist(p.start, p.startBusStops, p.capacities, false),
 		whitelist(p.target, p.targetBusStops, p.capacities, true)
 	]);
+
+	assertArraySizes(start, p.startBusStops, 'Whitelist', false);
+	assertArraySizes(target, p.targetBusStops, 'Whitelist', false);
+
 	if (p.directTimes.length != 0) {
 		direct = p.startFixed ? target[target.length - 1] : start[start.length - 1];
 		if (p.startFixed) {
@@ -55,10 +60,34 @@ export async function POST(event: RequestEvent) {
 			start = start.slice(0, start.length - 1);
 		}
 	}
+
+	console.assert(
+		direct.length === p.directTimes.length,
+		'Array size mismatch in Whitelist - direct.'
+	);
+	for (let i = 0; i != direct.length; ++i) {
+		console.assert(
+			direct[i] != null && direct[i] != undefined,
+			'Undefined in Whitelist Response. - direct'
+		);
+	}
+
 	const response: WhitelistResponse = {
 		start,
 		target,
 		direct
 	};
+	console.log(
+		'WHITELIST RESPONSE: ',
+		JSON.stringify(toWhitelistResponseWithISOStrings(response), null, '\t')
+	);
 	return json(response);
+}
+
+function toWhitelistResponseWithISOStrings(r: WhitelistResponse) {
+	return {
+		start: r.start.map((i) => i.map((j) => toInsertionWithISOStrings(j))),
+		target: r.target.map((i) => i.map((j) => toInsertionWithISOStrings(j))),
+		direct: r.direct.map((j) => toInsertionWithISOStrings(j))
+	};
 }


### PR DESCRIPTION
Commit Restrict times #191 introduced a bug where batchQueries were called with the full Array of BusStops

- Fix this by calling batchQueries on the appropraite slice
- Add assertions to verify for Blacklisting and Whitelisting that the sizes of the inputs match the associtated ouput sizes
- Add assertions verifying that Blacklisting Responses do not contain undefined or null entries