### PR TITLE
Dont restrict driving to company

### DIFF
--- a/src/lib/server/booking/api.test.ts
+++ b/src/lib/server/booking/api.test.ts
@@ -233,7 +233,7 @@ describe('Whitelist and Booking API Tests', () => {
 		expect(blackResponse.direct[0]).toBe(false);
 	});
 
-	it('whitelist fail because request would require taxi to operate outside of defined shift (6:00-21:00)', async () => {
+	it.only('whitelist fail because request would require taxi to operate outside of defined shift (6:00-21:00)', async () => {
 		const company = await addCompany(Zone.NIESKY, inNiesky3);
 		const taxi = await addTaxi(company, { passengers: 3, bikes: 0, wheelchairs: 0, luggage: 0 });
 		await setAvailability(taxi, inXMinutes(0), inXMinutes(600));
@@ -242,7 +242,7 @@ describe('Whitelist and Booking API Tests', () => {
 			target: inNiesky2,
 			startBusStops: [],
 			targetBusStops: [],
-			directTimes: [inXMinutes(106)],
+			directTimes: [inXMinutes(113)],
 			startFixed: true,
 			capacities
 		});

--- a/src/lib/server/booking/api.test.ts
+++ b/src/lib/server/booking/api.test.ts
@@ -233,7 +233,7 @@ describe('Whitelist and Booking API Tests', () => {
 		expect(blackResponse.direct[0]).toBe(false);
 	});
 
-	it.only('whitelist fail because request would require taxi to operate outside of defined shift (6:00-21:00)', async () => {
+	it('whitelist fail because request would require taxi to operate outside of defined shift (6:00-21:00)', async () => {
 		const company = await addCompany(Zone.NIESKY, inNiesky3);
 		const taxi = await addTaxi(company, { passengers: 3, bikes: 0, wheelchairs: 0, luggage: 0 });
 		await setAvailability(taxi, inXMinutes(0), inXMinutes(600));

--- a/src/lib/server/booking/durations.ts
+++ b/src/lib/server/booking/durations.ts
@@ -95,8 +95,7 @@ export function getAllowedOperationTimes(
 	next: DbEvent | undefined,
 	expandedSearchInterval: Interval,
 	prepTime: UnixtimeMs,
-	vehicle: VehicleWithInterval,
-	allowedTimes: Interval[]
+	vehicle: VehicleWithInterval
 ): Interval[] {
 	console.assert(
 		implication(!returnsToCompany(insertionCase), next !== undefined),
@@ -157,12 +156,9 @@ export function getAllowedOperationTimes(
 		!(insertionCase.how != InsertHow.NEW_TOUR && relevantAvailabilities.length > 1),
 		`Found ${relevantAvailabilities.length} intervals, which are supposed to be disjoint, containing the same timestamp.`
 	);
-	return Interval.intersect(
-		relevantAvailabilities
+	return relevantAvailabilities
 			.map((availability) => new Interval(availability).intersect(window))
-			.filter((availability) => availability != undefined),
-		allowedTimes
-	);
+			.filter((availability) => availability != undefined)
 }
 
 export function getArrivalWindow(
@@ -171,16 +167,14 @@ export function getArrivalWindow(
 	directDuration: number,
 	busStopWindow: Interval | undefined,
 	prevLegDuration: number,
-	nextLegDuration: number
+	nextLegDuration: number,
+	allowedTimes: Interval[]
 ): Interval | undefined {
-	const fullPrevLegDuration =
-		prevLegDuration +
-		(insertionCase.direction == InsertDirection.BUS_STOP_DROPOFF ? directDuration : 0);
-	const fullNextLegDuration =
-		nextLegDuration +
-		(insertionCase.direction == InsertDirection.BUS_STOP_PICKUP ? directDuration : 0);
+	const directWindows = Interval.intersect(allowedTimes, windows
+		.map((window) => window.shrink(prevLegDuration, nextLegDuration))
+		.filter((window) => window != undefined));
 	let arrivalWindows = windows
-		.map((window) => window.shrink(fullPrevLegDuration, fullNextLegDuration))
+		.map((window) => window.shrink(insertionCase.direction == InsertDirection.BUS_STOP_DROPOFF ? directDuration : 0, insertionCase.direction == InsertDirection.BUS_STOP_PICKUP ? directDuration : 0))
 		.filter((window) => window != undefined);
 	if (busStopWindow != undefined) {
 		arrivalWindows = arrivalWindows

--- a/src/lib/server/booking/durations.ts
+++ b/src/lib/server/booking/durations.ts
@@ -157,8 +157,8 @@ export function getAllowedOperationTimes(
 		`Found ${relevantAvailabilities.length} intervals, which are supposed to be disjoint, containing the same timestamp.`
 	);
 	return relevantAvailabilities
-			.map((availability) => new Interval(availability).intersect(window))
-			.filter((availability) => availability != undefined)
+		.map((availability) => new Interval(availability).intersect(window))
+		.filter((availability) => availability != undefined);
 }
 
 export function getArrivalWindow(
@@ -170,11 +170,19 @@ export function getArrivalWindow(
 	nextLegDuration: number,
 	allowedTimes: Interval[]
 ): Interval | undefined {
-	const directWindows = Interval.intersect(allowedTimes, windows
-		.map((window) => window.shrink(prevLegDuration, nextLegDuration))
-		.filter((window) => window != undefined));
-	let arrivalWindows = windows
-		.map((window) => window.shrink(insertionCase.direction == InsertDirection.BUS_STOP_DROPOFF ? directDuration : 0, insertionCase.direction == InsertDirection.BUS_STOP_PICKUP ? directDuration : 0))
+	const directWindows = Interval.intersect(
+		allowedTimes,
+		windows
+			.map((window) => window.shrink(prevLegDuration, nextLegDuration))
+			.filter((window) => window != undefined)
+	);
+	let arrivalWindows = directWindows
+		.map((window) =>
+			window.shrink(
+				insertionCase.direction == InsertDirection.BUS_STOP_DROPOFF ? directDuration : 0,
+				insertionCase.direction == InsertDirection.BUS_STOP_PICKUP ? directDuration : 0
+			)
+		)
 		.filter((window) => window != undefined);
 	if (busStopWindow != undefined) {
 		arrivalWindows = arrivalWindows

--- a/src/lib/server/booking/insertion.ts
+++ b/src/lib/server/booking/insertion.ts
@@ -140,6 +140,7 @@ export function evaluateBothInsertion(
 	busStopIdx: number | undefined,
 	prev: Event | undefined,
 	next: Event | undefined,
+	allowedTimes: Interval[],
 	_promisedTimes?: PromisedTimes // TODO
 ): InsertionEvaluation | undefined {
 	console.assert(
@@ -171,7 +172,8 @@ export function evaluateBothInsertion(
 		passengerDuration,
 		busStopWindow,
 		prevLegDuration,
-		nextLegDuration
+		nextLegDuration,
+		allowedTimes
 	);
 	if (arrivalWindow == undefined) {
 		return undefined;
@@ -271,8 +273,7 @@ export function evaluateNewTours(
 				undefined,
 				expandedSearchInterval,
 				prepTime,
-				vehicle,
-				allowedTimes
+				vehicle
 			);
 			for (let busStopIdx = 0; busStopIdx != busStopTimes.length; ++busStopIdx) {
 				for (let busTimeIdx = 0; busTimeIdx != busStopTimes[busStopIdx].length; ++busTimeIdx) {
@@ -286,6 +287,7 @@ export function evaluateNewTours(
 						busStopIdx,
 						undefined,
 						undefined,
+						allowedTimes,
 						promisedTimes
 					);
 					if (

--- a/src/routes/api/whitelist/+server.ts
+++ b/src/routes/api/whitelist/+server.ts
@@ -65,12 +65,6 @@ export async function POST(event: RequestEvent) {
 		direct.length === p.directTimes.length,
 		'Array size mismatch in Whitelist - direct.'
 	);
-	for (let i = 0; i != direct.length; ++i) {
-		console.assert(
-			direct[i] != null && direct[i] != undefined,
-			'Undefined in Whitelist Response. - direct'
-		);
-	}
 
 	const response: WhitelistResponse = {
 		start,


### PR DESCRIPTION
When doing the restriction of taxi activity to 6:00-21:00 berlin time ignore the duration for driving from the company to the first event and from the last event to the company.