### PR TITLE
MOTIS UI backports etc.

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 		"@sveltejs/kit": "^2.16.0",
 		"@sveltejs/vite-plugin-svelte": "^5.0.0",
 		"autoprefixer": "^10.4.20",
-		"bits-ui": "1.0.0-next.78",
+		"bits-ui": "1.0.0-next.87",
 		"clsx": "^2.1.1",
 		"eslint": "^9.18.0",
 		"eslint-config-prettier": "^10.0.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
 	webServer: {
 		command: 'npm run dev',
 		url: 'http://localhost:5173',
-		timeout: 20000,
+		timeout: 60000,
 		reuseExistingServer: true
 	},
 	use: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,8 +109,8 @@ importers:
         specifier: ^10.4.20
         version: 10.4.20(postcss@8.5.1)
       bits-ui:
-        specifier: 1.0.0-next.78
-        version: 1.0.0-next.78(svelte@5.19.2)
+        specifier: 1.0.0-next.87
+        version: 1.0.0-next.87(svelte@5.19.2)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -1135,8 +1135,8 @@ packages:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
 
-  bits-ui@1.0.0-next.78:
-    resolution: {integrity: sha512-jZjG2ObZ/CNyCNaXecpItC7hRXqJAgEfMhr06/eNrf3wHiiPyhdcy4OkzLcJyxeOrDyj+xma8cZTd3JRWqJdAw==}
+  bits-ui@1.0.0-next.87:
+    resolution: {integrity: sha512-3NCcz/7Fwp9zEqA4sCz6oGWrL3haDkIe15EwY6GnoInbFPtH0x3ftJ00dP45BqQ/RukYHcoW1pzRlUerdcIvxA==}
     engines: {node: '>=18', pnpm: '>=8.7.0'}
     peerDependencies:
       svelte: ^5.11.0
@@ -2368,13 +2368,8 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
-  runed@0.20.0:
-    resolution: {integrity: sha512-YqPxaUdWL5nUXuSF+/v8a+NkVN8TGyEGbQwTA25fLY35MR/2bvZ1c6sCbudoo1kT4CAJPh4kUkcgGVxW127WKw==}
-    peerDependencies:
-      svelte: ^5.7.0
-
-  runed@0.22.0:
-    resolution: {integrity: sha512-ZWVXWhOr0P5xdNgtviz6D1ivLUDWKLCbeC5SUEJ3zBkqLReVqWHenFxMNFeFaiC5bfxhFxyxzyzB+98uYFtwdA==}
+  runed@0.23.4:
+    resolution: {integrity: sha512-9q8oUiBYeXIDLWNK5DfCWlkL0EW3oGbk845VdKlPeia28l751VpfesaB/+7pI6rnbx1I6rqoZ2fZxptOJLxILA==}
     peerDependencies:
       svelte: ^5.7.0
 
@@ -2518,8 +2513,8 @@ packages:
     peerDependencies:
       svelte: ^5.0.0-next.126
 
-  svelte-toolbelt@0.7.0:
-    resolution: {integrity: sha512-i/Tv4NwAWWqJnK5H0F8y/ubDnogDYlwwyzKhrspTUFzrFuGnYshqd2g4/R43ds841wmaFiSW/HsdsdWhPOlrAA==}
+  svelte-toolbelt@0.7.1:
+    resolution: {integrity: sha512-HcBOcR17Vx9bjaOceUvxkY3nGmbBmCBBbuWLLEWO6jtmWH8f/QoWmbyUfQZrpDINH39en1b8mptfPQT9VKQ1xQ==}
     engines: {node: '>=18', pnpm: '>=8.7.0'}
     peerDependencies:
       svelte: ^5.0.0
@@ -3620,15 +3615,15 @@ snapshots:
 
   binary-extensions@2.3.0: {}
 
-  bits-ui@1.0.0-next.78(svelte@5.19.2):
+  bits-ui@1.0.0-next.87(svelte@5.19.2):
     dependencies:
       '@floating-ui/core': 1.6.9
       '@floating-ui/dom': 1.6.13
       '@internationalized/date': 3.7.0
       esm-env: 1.2.2
-      runed: 0.22.0(svelte@5.19.2)
+      runed: 0.23.4(svelte@5.19.2)
       svelte: 5.19.2
-      svelte-toolbelt: 0.7.0(svelte@5.19.2)
+      svelte-toolbelt: 0.7.1(svelte@5.19.2)
 
   brace-expansion@1.1.11:
     dependencies:
@@ -4826,12 +4821,7 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
-  runed@0.20.0(svelte@5.19.2):
-    dependencies:
-      esm-env: 1.2.2
-      svelte: 5.19.2
-
-  runed@0.22.0(svelte@5.19.2):
+  runed@0.23.4(svelte@5.19.2):
     dependencies:
       esm-env: 1.2.2
       svelte: 5.19.2
@@ -4974,10 +4964,10 @@ snapshots:
       style-to-object: 1.0.8
       svelte: 5.19.2
 
-  svelte-toolbelt@0.7.0(svelte@5.19.2):
+  svelte-toolbelt@0.7.1(svelte@5.19.2):
     dependencies:
       clsx: 2.1.1
-      runed: 0.20.0(svelte@5.19.2)
+      runed: 0.23.4(svelte@5.19.2)
       style-to-object: 1.0.8
       svelte: 5.19.2
 
@@ -5137,7 +5127,7 @@ snapshots:
 
   vaul-svelte@1.0.0-next.3(svelte@5.19.2):
     dependencies:
-      bits-ui: 1.0.0-next.78(svelte@5.19.2)
+      bits-ui: 1.0.0-next.87(svelte@5.19.2)
       svelte: 5.19.2
       svelte-toolbelt: 0.4.6(svelte@5.19.2)
 

--- a/src/app.html
+++ b/src/app.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="overflow-hidden">
 	<head>
 		<meta charset="utf-8" />
 		<link rel="icon" href="%sveltekit.assets%/favicon.png" />

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -172,6 +172,7 @@ const translations: Translations = {
 	sharingProvider: 'Anbieter',
 	roundtripStationReturnConstraint:
 		'Das Fahrzeug muss wieder an der Abfahrtsstation abgestellt werden.',
+	noItinerariesFound: 'Keine Verbindungen gefunden.',
 
 	bookingInfo: 'Buchungsangaben',
 	changeBookingInfo: 'Ändern Sie Ihre Such- und Buchungsangaben.',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -170,7 +170,8 @@ const translations: Translations = {
 	},
 	sharingProvider: 'Provider',
 	roundtripStationReturnConstraint: 'The vehicle must be returned to the departure station.',
-
+	noItinerariesFound: 'Keine Verbindungen gefunden.',
+	
 	bookingInfo: 'Booking Information',
 	changeBookingInfo: 'Change your search options and booking information.',
 

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -170,7 +170,7 @@ const translations: Translations = {
 	},
 	sharingProvider: 'Provider',
 	roundtripStationReturnConstraint: 'The vehicle must be returned to the departure station.',
-	noItinerariesFound: 'Keine Verbindungen gefunden.',
+	noItinerariesFound: 'No itineraries found.',
 
 	bookingInfo: 'Booking Information',
 	changeBookingInfo: 'Change your search options and booking information.',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -171,7 +171,7 @@ const translations: Translations = {
 	sharingProvider: 'Provider',
 	roundtripStationReturnConstraint: 'The vehicle must be returned to the departure station.',
 	noItinerariesFound: 'Keine Verbindungen gefunden.',
-	
+
 	bookingInfo: 'Booking Information',
 	changeBookingInfo: 'Change your search options and booking information.',
 

--- a/src/lib/i18n/translation.ts
+++ b/src/lib/i18n/translation.ts
@@ -152,6 +152,7 @@ export type Translations = {
 	tripIntermediateStops: (n: number) => string;
 	sharingProvider: string;
 	roundtripStationReturnConstraint: string;
+	noItinerariesFound: string;
 	bookingInfo: string;
 	changeBookingInfo: string;
 	booking: {

--- a/src/lib/ui/AddressTypeahead.svelte
+++ b/src/lib/ui/AddressTypeahead.svelte
@@ -120,7 +120,6 @@
 			shown.add(entry);
 			return true;
 		});
-		preventClickthrough(!!items.length && comboOpen);
 	};
 
 	const deserialize = (s: string): Location => {
@@ -155,16 +154,6 @@
 		}
 	});
 
-	let comboOpen = false;
-	const preventClickthrough = (prevent: boolean) => {
-		const ctr = document.getElementById('searchmask-container')!;
-		if (prevent) {
-			ctr.style.pointerEvents = 'none';
-		} else {
-			window.setTimeout(() => (ctr.style.pointerEvents = 'auto'), 1);
-		}
-	};
-
 	onMount(() => ref?.focus());
 </script>
 
@@ -180,10 +169,6 @@
 				onValueChange(selected);
 			}
 		}
-	}}
-	onOpenChange={(open) => {
-		comboOpen = open;
-		preventClickthrough(open);
 	}}
 >
 	<Combobox.Input

--- a/src/routes/(customer)/bookings/[slug]/+page.svelte
+++ b/src/routes/(customer)/bookings/[slug]/+page.svelte
@@ -24,7 +24,7 @@
 	let showTicket = $state(false);
 </script>
 
-<div class="flex h-full flex-col gap-4 md:h-[80%] md:w-96">
+<div class="flex h-full flex-col gap-4 md:min-h-[70dvh] md:w-96">
 	{#if !data.cancelled}
 		<div class="flex items-center justify-between gap-4">
 			<Button variant="outline" size="icon" onclick={() => window.history.back()}>

--- a/src/routes/(customer)/rating/[slug]/+page.svelte
+++ b/src/routes/(customer)/rating/[slug]/+page.svelte
@@ -14,7 +14,7 @@
 	const { data, form } = $props();
 </script>
 
-<div class="flex h-full flex-col gap-4 md:h-[80%] md:w-96">
+<div class="flex h-full flex-col gap-4 md:min-h-[70dvh] md:w-96">
 	{#if form?.msg}
 		<Message msg={form.msg} class="mb-4" />
 	{:else if !data.rated}

--- a/src/routes/(customer)/routing/+page.svelte
+++ b/src/routes/(customer)/routing/+page.svelte
@@ -306,11 +306,11 @@
 				/>
 				<Button
 					variant="ghost"
-					class="absolute z-10 right-0 top-0"
+					class="absolute right-0 top-0 z-10"
 					size="icon"
 					onclick={() => getLocation()}
 				>
-					<LocateFixed class="w-5 h-5" />
+					<LocateFixed class="h-5 w-5" />
 				</Button>
 				<Button
 					class="absolute right-10 top-6 z-10 rounded-full"

--- a/src/routes/(customer)/routing/+page.svelte
+++ b/src/routes/(customer)/routing/+page.svelte
@@ -139,7 +139,7 @@
 	};
 </script>
 
-<div class="md:h-[80%] md:w-96">
+<div class="md:min-h-[70dvh] md:w-96">
 	<Message msg={form?.msg} class="mb-4" />
 
 	{#if page.state.selectFrom}

--- a/src/routes/(customer)/routing/+page.svelte
+++ b/src/routes/(customer)/routing/+page.svelte
@@ -40,6 +40,8 @@
 	import { updateStartDest } from '$lib/util/updateStartDest';
 	import { odmPrice } from '$lib/util/odmPrice';
 	import BookingSummary from '$lib/ui/BookingSummary.svelte';
+	import { LocateFixed } from 'lucide-svelte';
+	import { posToLocation } from '$lib/map/Location';
 
 	type LuggageType = 'none' | 'light' | 'heavy';
 
@@ -136,6 +138,18 @@
 			return;
 		}
 		pushState('', { selectedItinerary: itinerary });
+	};
+
+	const getLocation = () => {
+		if (navigator && navigator.geolocation) {
+			navigator.geolocation.getCurrentPosition(applyPosition, (e) => console.log(e), {
+				enableHighAccuracy: true
+			});
+		}
+	};
+
+	const applyPosition = (position: { coords: { latitude: number; longitude: number } }) => {
+		from = posToLocation({ lat: position.coords.latitude, lon: position.coords.longitude }, 0);
 	};
 </script>
 
@@ -291,7 +305,15 @@
 					value={to.label}
 				/>
 				<Button
-					class="absolute right-4 top-6 z-10 rounded-full"
+					variant="ghost"
+					class="absolute z-10 right-0 top-0"
+					size="icon"
+					onclick={() => getLocation()}
+				>
+					<LocateFixed class="w-5 h-5" />
+				</Button>
+				<Button
+					class="absolute right-10 top-6 z-10 rounded-full"
 					size="icon"
 					onclick={() => {
 						const tmp = to;

--- a/src/routes/(customer)/routing/ConnectionDetail.svelte
+++ b/src/routes/(customer)/routing/ConnectionDetail.svelte
@@ -87,7 +87,7 @@
 		{#if l.routeShortName}
 			<div class="flex w-full items-center justify-between space-x-1">
 				<Route {onClickTrip} {l} />
-				{#if pred && (pred.from.track || pred.duration !== 0)}
+				{#if pred && (pred.from.track || pred.duration !== 0) && (i != 1 || pred.routeShortName)}
 					<div class="h-0 shrink grow border-t"></div>
 					<div class="px-2 text-sm leading-none text-muted-foreground">
 						{#if pred.from.track}

--- a/src/routes/(customer)/routing/ItineraryList.svelte
+++ b/src/routes/(customer)/routing/ItineraryList.svelte
@@ -101,6 +101,8 @@
 					{/await}
 				{/each}
 			</div>
+		{:else}
+			<div>{t.noItinerariesFound}</div>
 		{/if}
 	{/await}
 {/if}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -57,10 +57,10 @@
 			</Alert.Description>
 		</Alert.Root>
 	{/if}
-	<div class="overflow-y-auto grow">
+	<div class="grow overflow-y-auto">
 		<div
 			id="searchmask-container"
-			class="p-2 pb-6 min-h-full md:flex md:items-center md:justify-center"
+			class="min-h-full p-2 pb-6 md:flex md:items-center md:justify-center"
 		>
 			{@render children()}
 		</div>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -57,11 +57,8 @@
 			</Alert.Description>
 		</Alert.Root>
 	{/if}
-	<div class="grow overflow-y-auto">
-		<div
-			id="searchmask-container"
-			class="min-h-full p-2 pb-6 md:flex md:items-center md:justify-center"
-		>
+	<div class="flex grow flex-col overflow-y-auto">
+		<div id="searchmask-container" class="grow p-2 pb-6 md:flex md:items-center md:justify-center">
 			{@render children()}
 		</div>
 	</div>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -57,11 +57,13 @@
 			</Alert.Description>
 		</Alert.Root>
 	{/if}
-	<div
-		id="searchmask-container"
-		class="grow overflow-y-auto p-2 pb-6 md:flex md:items-center md:justify-center"
-	>
-		{@render children()}
+	<div class="overflow-y-auto grow">
+		<div
+			id="searchmask-container"
+			class="p-2 pb-6 min-h-full md:flex md:items-center md:justify-center"
+		>
+			{@render children()}
+		</div>
 	</div>
 	<Menu class="shrink" {items} />
 </div>

--- a/src/routes/account/Form.svelte
+++ b/src/routes/account/Form.svelte
@@ -41,7 +41,7 @@
 		{#if type == 'signup'}
 			Durch die Anmeldung stimme ich den
 			<a href="/tos" class="border-b border-dotted border-muted-foreground">
-				Allgemeinen&nbsp;Geschäftsbedingen
+				Allgemeinen&nbsp;Geschäftsbedingungen
 			</a>
 			sowie der
 			<a href="/privacy" class="border-b border-dotted border-muted-foreground">

--- a/src/routes/taxi/availability/AddVehicle.svelte
+++ b/src/routes/taxi/availability/AddVehicle.svelte
@@ -21,7 +21,7 @@
 		Fahrzeug hinzufügen
 	</Popover.Trigger>
 	<Popover.Content>
-		<form method="post" action="?/addVehicle" class="flex flex-col gap-4" use:enhance>
+		<form method="post" action="?/addVehicle" class="flex flex-col gap-4" use:enhance={() => async ({ update }) => await update({ reset: false })}>
 			<h2 class="font-medium leading-none">Neues Fahrzeug</h2>
 
 			<div class="field">

--- a/src/routes/taxi/availability/AddVehicle.svelte
+++ b/src/routes/taxi/availability/AddVehicle.svelte
@@ -21,7 +21,14 @@
 		Fahrzeug hinzufügen
 	</Popover.Trigger>
 	<Popover.Content>
-		<form method="post" action="?/addVehicle" class="flex flex-col gap-4" use:enhance={() => async ({ update }) => await update({ reset: false })}>
+		<form
+			method="post"
+			action="?/addVehicle"
+			class="flex flex-col gap-4"
+			use:enhance={() =>
+				async ({ update }) =>
+					await update({ reset: false })}
+		>
 			<h2 class="font-medium leading-none">Neues Fahrzeug</h2>
 
 			<div class="field">


### PR DESCRIPTION
* MOTIS backports (route from location, don't show initial walking duration twice, show error when no itineraries found...)
* fix scrolling as per #233, since this actually occurs for all pages with more content
* some more minor UI fixes

Is there a specific reason that direct (walking) connections are not shown (compare [motis/ItineraryList.svelte#L66](https://github.com/motis-project/motis/blob/99bfdad7e65762fc6a8ca4d814954aaecc9512e9/ui/src/lib/ItineraryList.svelte#L66))? ODM direct connections are returned as part of normal itineraries, but walking connections are not I think.