### PR TITLE
keepsPromise should not fail, because of rounding

### DIFF
--- a/src/lib/server/booking/durations.ts
+++ b/src/lib/server/booking/durations.ts
@@ -194,6 +194,6 @@ export function getArrivalWindow(
 	}
 	// TODO why?
 	return insertionCase.direction == InsertDirection.BUS_STOP_PICKUP
-		? arrivalWindows.reduce((current, best) => (current.endTime > best.endTime ? current : best))
-		: arrivalWindows.reduce((current, best) => (current.endTime < best.endTime ? current : best));
+		? arrivalWindows.reduce((current, best) => (current.endTime < best.endTime ? current : best))
+		: arrivalWindows.reduce((current, best) => (current.endTime > best.endTime ? current : best));
 }

--- a/src/lib/server/util/interval.ts
+++ b/src/lib/server/util/interval.ts
@@ -1,3 +1,4 @@
+import { MINUTE } from '$lib/util/time';
 import type { UnixtimeMs } from '$lib/util/UnixtimeMs';
 
 export enum INTERVAL_RELATION {
@@ -108,6 +109,13 @@ export class Interval {
 
 	shift(x: number): Interval {
 		return new Interval(this.startTime + x, this.endTime + x);
+	}
+
+	round(): Interval {
+		return new Interval(
+			Math.floor(this.startTime / MINUTE) * MINUTE,
+			Math.ceil(this.endTime / MINUTE) * MINUTE
+		);
 	}
 
 	static intersect(a: Interval[], b: Interval[]): Interval[] {

--- a/src/lib/server/util/roundToNextFullMinute.ts
+++ b/src/lib/server/util/roundToNextFullMinute.ts
@@ -1,6 +1,0 @@
-import { MINUTE } from '$lib/util/time';
-import type { UnixtimeMs } from '$lib/util/UnixtimeMs';
-
-export function roundToNextFullMinute(timestamp: UnixtimeMs): UnixtimeMs {
-	return Math.ceil(timestamp / MINUTE) * MINUTE;
-}


### PR DESCRIPTION
Ensure that rounding the Whitelist result's timestamps to full minutes before passing them
to the Booking API does not cause the keepsPromise check to fail.
closes#206