### PR TITLE
Minor changes in /bookings route view

### DIFF
--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -154,6 +154,7 @@ const translations: Translations = {
 			year: isToday ? undefined : '2-digit'
 		}),
 
+	cancelledJourneys: 'Vergangene und stornierte Fahrten',
 	journeyDetails: 'Verbindungsdetails',
 	transfer: 'Umstieg',
 	transfers: 'Umstiege',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -150,6 +150,7 @@ const translations: Translations = {
 			year: isToday ? undefined : '2-digit'
 		}),
 
+	cancelledJourneys: 'Past and Cancelled Journeys',
 	journeyDetails: 'Journey Details',
 	transfer: 'transfer',
 	transfers: 'transfers',

--- a/src/lib/i18n/translation.ts
+++ b/src/lib/i18n/translation.ts
@@ -140,6 +140,7 @@ export type Translations = {
 
 	atDateTime: (timeType: TimeType, time: Date, isToday: boolean) => string;
 
+	cancelledJourneys: string;
 	journeyDetails: string;
 	transfer: string;
 	transfers: string;

--- a/src/routes/(customer)/bookings/+page.server.ts
+++ b/src/routes/(customer)/bookings/+page.server.ts
@@ -1,21 +1,42 @@
 import type { PageServerLoad } from './$types';
 import { db } from '$lib/server/db';
 import type { Itinerary } from '$lib/openapi';
+import { jsonArrayFrom } from 'kysely/helpers/postgres';
 
 export const load: PageServerLoad = async ({ locals }) => {
 	const journeys = await db
 		.selectFrom('journey')
 		.innerJoin('request', 'journey.request1', 'request.id')
-		.select(['json', 'journey.id as journeyId', 'request.ticketCode', 'request.cancelled'])
+		.innerJoin('tour', 'tour.id', 'request.tour')
+		.orderBy('tour.departure asc')
+		.select((eb) => [
+			jsonArrayFrom(
+				eb
+					.selectFrom('event')
+					.whereRef('event.request', '=', 'request.id')
+					.orderBy('isPickup', 'desc')
+					.select(['event.address'])
+			).as('addresses'),
+			'json',
+			'journey.id as journeyId',
+			'request.ticketCode',
+			'request.cancelled',
+			'tour.arrival'
+		])
 		.where('user', '=', locals.session!.userId!)
 		.execute();
 	return {
 		journeys: journeys.map((journey) => {
 			return {
-				journey: JSON.parse(journey.json) as Itinerary,
+				journey: {
+					...(JSON.parse(journey.json) as Itinerary),
+					startAddress: journey.addresses[0].address,
+					targetAddress: journey.addresses[1].address
+				},
 				id: journey.journeyId,
 				ticketCode: journey.ticketCode,
-				cancelled: journey.cancelled
+				cancelled: journey.cancelled,
+				arrival: journey.arrival
 			};
 		})
 	};

--- a/src/routes/(customer)/bookings/+page.svelte
+++ b/src/routes/(customer)/bookings/+page.svelte
@@ -2,8 +2,11 @@
 	import Alert from 'lucide-svelte/icons/triangle-alert';
 	import ItinerarySummary from '../routing/ItinerarySummary.svelte';
 	import { t } from '$lib/i18n/translation';
+	import type { Itinerary } from '$lib/openapi';
 
 	const { data } = $props();
+	const pastJourneys = data.journeys.filter((j) => j.cancelled || j.arrival < Date.now());
+	const plannedJourneys = data.journeys.filter((j) => !j.cancelled && j.arrival >= Date.now());
 </script>
 
 {#snippet cancelled()}
@@ -11,10 +14,29 @@
 	{t.msg.cancelled}
 {/snippet}
 
+{#snippet journeyList(
+	journeys: {
+		journey: Itinerary & {
+			startAddress: string;
+			targetAddress: string;
+		};
+		id: number;
+		ticketCode: string;
+		cancelled: boolean;
+		arrival: number;
+	}[]
+)}
+	<div class="flex flex-col gap-4">
+		{#each journeys as it}
+			<a href="/bookings/{it.id}">
+				<ItinerarySummary it={it.journey} info={it.cancelled ? cancelled : undefined} />
+			</a>
+		{/each}
+	</div>
+{/snippet}
+
 <div class="flex flex-col gap-4">
-	{#each data.journeys as it}
-		<a href="/bookings/{it.id}">
-			<ItinerarySummary it={it.journey} info={it.cancelled ? cancelled : undefined} />
-		</a>
-	{/each}
+	{@render journeyList(plannedJourneys)}
+	{t.cancelledJourneys}
+	{@render journeyList(pastJourneys)}
 </div>

--- a/src/routes/(customer)/routing/ItinerarySummary.svelte
+++ b/src/routes/(customer)/routing/ItinerarySummary.svelte
@@ -13,7 +13,7 @@
 		baseQuery,
 		info
 	}: {
-		it: Itinerary;
+		it: Itinerary & { startAddress?: string; targetAddress?: string };
 		baseQuery?: PlanData | undefined;
 		info?: Snippet<[Itinerary]> | undefined;
 	} = $props();
@@ -43,6 +43,11 @@
 			{it.transfers}
 			{t.transfers}
 		</div>
+		{#if it.startAddress !== undefined && it.targetAddress !== undefined}
+			<span class="break-words text-left">
+				{it.startAddress} -> {it.targetAddress}
+			</span>
+		{/if}
 		<span class="text-left">
 			<Time
 				class="inline"


### PR DESCRIPTION
Display journeys in /bookings in order of planned departure
Display journeys in /bookings in two blocks (cancelled + past
	at the bottom, present + future at the top)
Display start- and target addresses in /bookings in each
	ItinerarySummary