### PR TITLE
disable booking button when clicked

### DIFF
--- a/src/routes/(customer)/routing/+page.svelte
+++ b/src/routes/(customer)/routing/+page.svelte
@@ -182,6 +182,8 @@
 	const applyPosition = (position: { coords: { latitude: number; longitude: number } }) => {
 		from = posToLocation({ lat: position.coords.latitude, lon: position.coords.longitude }, 0);
 	};
+
+	let loading = $state(false);
 </script>
 
 <Meta title={PUBLIC_PROVIDER} />
@@ -248,7 +250,19 @@
 									page.state.selectedItinerary.legs.length === 1 &&
 									page.state.selectedItinerary.legs[0].mode === 'ODM'}
 
-								<form method="post" action="?/bookItineraryWithOdm" use:enhance>
+								<form
+									method="post"
+									action="?/bookItineraryWithOdm"
+									use:enhance={() => {
+										loading = true;
+										return async ({ update }) => {
+											await update();
+											window.setTimeout(() => {
+												loading = false;
+											}, 5000);
+										};
+									}}
+								>
 									<input
 										type="hidden"
 										name="json"
@@ -304,7 +318,9 @@
 									<input type="hidden" name="kidsFiveToSix" value={kidsFiveToSix} />
 									<input type="hidden" name="luggage" value={luggageToInt(luggage)} />
 									<input type="hidden" name="wheelchairs" value={wheelchair ? 1 : 0} />
-									<Button type="submit" variant="outline">{t.booking.header}</Button>
+									<Button type="submit" variant="outline" disabled={loading}
+										>{t.booking.header}</Button
+									>
 								</form>
 							</Dialog.Footer>
 						</Dialog.Content>


### PR DESCRIPTION
In the monitoring/logging I saw two exactly identical bookings executed within a few milliseconds (the second booking rightfully failing). I suppose this was someone clicking on the booking button twice -> disabling the button while the booking is in flight.
Timeout necessary because otherwise it gets enabled again for a short time between the response returning and the redirect to /bookings (or the error message) happening.