### PR TITLE
Ridesharing UI: Berechnete Route besser kommunizieren

### DIFF
--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -454,7 +454,10 @@ const translations: Translations = {
 		howHasItBeen: 'Sie können Ihre letzte Mitfahrerfahrung hier bewerten',
 		editVehicle: 'Fahrzeug ändern',
 		closeTo: 'in der Nähe von',
-		defaultLicensePlate: 'Standardfahrzeug'
+		defaultLicensePlate: 'Standardfahrzeug',
+		calculatedRoute: 'Berechnete Route',
+		travelTimeOnly: 'reine Fahrzeit',
+		maxTime: 'maximal bei Mitnahme'
 	},
 
 	calibration: {

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -94,8 +94,8 @@ const translations: Translations = {
 		routingRequestFailed: 'Routinganfrage fehlgeschlagen.',
 		vehicleConflict:
 			'Das gewählte Fahrzeug ist zu mindestens einem der gewählten Zeitpunkte nicht verfügbar.',
-		previousLegConflict: 'previous leg conflict',
-		nextLegConflict: 'next leg conflict',
+		previousLegConflict: 'Die neue Fahrt ist mit einem Mitnahmeangebot davor nicht vereinbar.',
+		nextLegConflict: 'Die neue Fahrt ist mit einem Mitnahmeangebot danach nicht vereinbar.',
 		allowedIntervalsConflict: 'Das gewählte Fahrzeug ist zur angegebenen Zeit nicht verfügbar.',
 
 		// Booking

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -94,6 +94,9 @@ const translations: Translations = {
 		routingRequestFailed: 'Routinganfrage fehlgeschlagen.',
 		vehicleConflict:
 			'Das gewählte Fahrzeug ist zu mindestens einem der gewählten Zeitpunkte nicht verfügbar.',
+		previousLegConflict: 'previous leg conflict',
+		nextLegConflict: 'next leg conflict',
+		allowedIntervalsConflict: 'Das gewählte Fahrzeug ist zur angegebenen Zeit nicht verfügbar.',
 
 		// Booking
 		bookingError: 'Die Fahrt konnte nicht gebucht werden. Bitte führen Sie eine neue Suche durch.',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -442,7 +442,10 @@ const translations: Translations = {
 		howHasItBeen: 'You can rate your last ride share experience here',
 		editVehicle: 'Edit Vehicle',
 		closeTo: 'close to',
-		defaultLicensePlate: 'Default vehicle'
+		defaultLicensePlate: 'Default vehicle',
+		calculatedRoute: 'Calculated route',
+		travelTimeOnly: 'actual travel time',
+		maxTime: 'maximum if ridesharing'
 	},
 
 	calibration: {

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -90,6 +90,9 @@ const translations: Translations = {
 		noVehicle: 'No vehicle available.',
 		routingRequestFailed: 'Routing request failed.',
 		vehicleConflict: 'The selected vehicle is not available at at least one of the selected times.',
+		previousLegConflict: 'previous leg conflict',
+		nextLegConflict: 'next leg conflict',
+		allowedIntervalsConflict: 'The seleceted vehicle is not available at the selected time',
 
 		// Booking
 		bookingError: 'The ride could not be booked. Please start a new search.',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -90,8 +90,8 @@ const translations: Translations = {
 		noVehicle: 'No vehicle available.',
 		routingRequestFailed: 'Routing request failed.',
 		vehicleConflict: 'The selected vehicle is not available at at least one of the selected times.',
-		previousLegConflict: 'previous leg conflict',
-		nextLegConflict: 'next leg conflict',
+		previousLegConflict: 'The new trip is not compatible with a previous ride-sharing offer.',
+		nextLegConflict: 'The new trip is not compatible with a subsequent ride-sharing offer.',
 		allowedIntervalsConflict: 'The seleceted vehicle is not available at the selected time',
 
 		// Booking

--- a/src/lib/i18n/translation.ts
+++ b/src/lib/i18n/translation.ts
@@ -384,6 +384,9 @@ export type Translations = {
 		editVehicle: string;
 		closeTo: string;
 		defaultLicensePlate: string;
+		calculatedRoute: string;
+		travelTimeOnly: string;
+		maxTime: string;
 	};
 
 	calibration: {

--- a/src/lib/i18n/translation.ts
+++ b/src/lib/i18n/translation.ts
@@ -89,6 +89,9 @@ export type Translations = {
 		noVehicle: string;
 		routingRequestFailed: string;
 		vehicleConflict: string;
+		previousLegConflict: string;
+		nextLegConflict: string;
+		allowedIntervalsConflict: string;
 
 		// Booking
 		bookingError: string;

--- a/src/lib/server/booking/rideShare/addRideShareTour.ts
+++ b/src/lib/server/booking/rideShare/addRideShareTour.ts
@@ -28,6 +28,7 @@ export async function getRideShareTourCommunicatedTimes(
 		: {
 				start: r[0].startTimeStart,
 				end: r[0].targetTimeEnd,
+				duration: r[0].duration,
 				routeDistanceMeters: r[0].routeDistanceMeters
 			};
 }

--- a/src/lib/server/booking/rideShare/addRideShareTour.ts
+++ b/src/lib/server/booking/rideShare/addRideShareTour.ts
@@ -12,6 +12,7 @@ import type { Transaction } from 'kysely';
 import { prepareDetourEllipse } from '$lib/util/booking/ellipse';
 import type { Itinerary } from '$lib/openapi';
 import { isCarLeg } from '$lib/util/booking/checkLegType';
+import { msg, type Msg } from '$lib/msg';
 
 export async function getRideShareTourCommunicatedTimes(
 	time: number,
@@ -22,8 +23,8 @@ export async function getRideShareTourCommunicatedTimes(
 	checkConflicts?: boolean
 ) {
 	const r = await util([time], startFixed, vehicle, start, target, checkConflicts);
-	return r[0] === undefined
-		? undefined
+	return 'type' in r[0]
+		? r[0]
 		: {
 				start: r[0].startTimeStart,
 				end: r[0].targetTimeEnd,
@@ -52,7 +53,7 @@ async function util(
 				duration: number;
 				routeDistanceMeters: number;
 		  }
-		| undefined
+		| Msg
 	)[]
 > {
 	const route = await carRouting(
@@ -66,7 +67,7 @@ async function util(
 	const routeDistanceMeters = route === undefined ? undefined : getRouteDistanceMeters(route);
 	if (!duration || routeDistanceMeters === undefined) {
 		console.log('adding tour: routing failed');
-		return Array.from(times, (_) => undefined);
+		return Array.from(times, (_) => msg('noRouteFound'));
 	}
 	const results = [];
 	for (const time of times) {
@@ -150,7 +151,7 @@ async function util(
 			const prevLegDurationResult = (await oneToManyCarRouting(lastTourEvent, [start], false))[0];
 			if (!prevLegDurationResult) {
 				console.log('adding tour: previous leg conflict', prevLegDurationResult, lastEventBefore);
-				results.push(undefined);
+				results.push(msg('previousLegConflict'));
 				continue;
 			}
 			allowedIntervals = Interval.subtract(allowedIntervals, [
@@ -169,7 +170,7 @@ async function util(
 			const nextLegDurationResult = (await oneToManyCarRouting(target, [firstTourEvent], false))[0];
 			if (!nextLegDurationResult) {
 				console.log('adding tour: next leg conflict', nextLegDurationResult, firstEventAfter);
-				results.push(undefined);
+				results.push(msg('nextLegConflict'));
 				continue;
 			}
 			allowedIntervals = Interval.subtract(allowedIntervals, [
@@ -184,7 +185,7 @@ async function util(
 		);
 		if (allowedIntervals.length === 0) {
 			console.log('adding tour: allowed intervals conflict', allowedIntervals);
-			results.push(undefined);
+			results.push(msg('allowedIntervalsConflict'));
 			continue;
 		}
 		const bestInterval = allowedIntervals.reduce(
@@ -282,12 +283,12 @@ export const addRideShareTour = async (
 		).id;
 	}
 	const timesResults = await util(times, startFixed, vehicle, start, target);
-	if (timesResults.length === 1 && timesResults[0] === undefined) {
+	if (timesResults.length === 1 && 'type' in timesResults[0]) {
 		return undefined;
 	}
 	const tourIds = [];
 	for (const timesResult of timesResults) {
-		if (timesResult === undefined) {
+		if ('type' in timesResult) {
 			tourIds.push(undefined);
 			continue;
 		}

--- a/src/lib/server/booking/rideShare/tests/bookToRSTour.test.ts
+++ b/src/lib/server/booking/rideShare/tests/bookToRSTour.test.ts
@@ -64,7 +64,9 @@ describe('add ride share request', () => {
 			inSchleife,
 			inKleinPriebus
 		);
-		expect(communicatedTimesStartFixed?.start).toBe(inXMinutes(40));
+		if ('start' in communicatedTimesStartFixed) {
+			expect(communicatedTimesStartFixed.start).toBe(inXMinutes(40));
+		}
 		const communicatedTimesStartNotFixed = await getRideShareTourCommunicatedTimes(
 			inXMinutes(40),
 			false,
@@ -72,7 +74,9 @@ describe('add ride share request', () => {
 			inSchleife,
 			inKleinPriebus
 		);
-		expect(communicatedTimesStartNotFixed?.end).toBe(inXMinutes(40));
+		if ('end' in communicatedTimesStartNotFixed) {
+			expect(communicatedTimesStartNotFixed.end).toBe(inXMinutes(40));
+		}
 	});
 	it('simple success case', async () => {
 		const vehicle = await createRideShareVehicle(

--- a/src/routes/(customer)/ride-offers/new/+page.svelte
+++ b/src/routes/(customer)/ride-offers/new/+page.svelte
@@ -272,6 +272,10 @@
 		updatedTime.setHours(hours, minutes, 0, 0);
 		repeatingTime = updatedTime;
 	}
+
+	function floorToMinute(value: number) {
+		return Math.floor(value / 60) * 60;
+	}
 </script>
 
 {#snippet timeTypeControls(idPrefix: TimeControlMode)}
@@ -641,14 +645,14 @@
 							</div>
 							<div class="flex items-center text-muted-foreground">
 								<EllipsisVertical class="ml-2 mr-6" />
-								{formatDurationSec(page.state.selectedItinerary?.duration)}
+								{formatDurationSec(floorToMinute(page.state.selectedItinerary?.duration))}
 								{t.rideShare.maxTime}
 							</div>
 							<div class="flex items-center text-muted-foreground">
 								<EllipsisVertical class="ml-2 mr-6" />
 								{formatDurationSec(
-									page.state.selectedItinerary?.duration /
-										(1 + SCHEDULED_TIME_BUFFER_DROPOFF_RELATIVE)
+									floorToMinute(page.state.selectedItinerary?.duration /
+										(1 + SCHEDULED_TIME_BUFFER_DROPOFF_RELATIVE))
 								)}
 								{t.rideShare.travelTimeOnly}
 							</div>

--- a/src/routes/(customer)/ride-offers/new/+page.svelte
+++ b/src/routes/(customer)/ride-offers/new/+page.svelte
@@ -626,8 +626,7 @@
 					</Card.Header>
 					<Card.Content>
 						<div class="flex-row">
-							<div class="flex items-center">
-								<MapPin class="mr-2 h-5 w-5" />
+							<div class="flex items-center overflow-hidden">
 								<Time
 									variant="schedule"
 									class="mr-4 w-auto font-semibold "
@@ -639,17 +638,16 @@
 								{from.label ? from.label : t.departure}
 							</div>
 							<div class="flex items-center text-muted-foreground">
-								<EllipsisVertical class="mr-2 h-5 w-5" />
+								<EllipsisVertical class="ml-2 mr-6" />
 								{formatDurationSec(page.state.selectedItinerary?.duration)}
 								{t.rideShare.maxTime}
 							</div>
 							<div class="flex items-center text-muted-foreground">
-								<EllipsisVertical class="mr-2 h-5 w-5" />
+								<EllipsisVertical class="ml-2 mr-6" />
 								{formatDurationSec(page.state.selectedItinerary?.duration / (1+SCHEDULED_TIME_BUFFER_DROPOFF_RELATIVE)) }
 								{t.rideShare.travelTimeOnly}
 							</div>
-							<div class="flex w-fit items-center">
-								<MapPinCheckInside class="size-5 mr-2" />
+							<div class="flex items-center overflow-hidden">
 								<Time
 									variant="schedule"
 									class="mr-4 w-auto font-semibold"

--- a/src/routes/(customer)/ride-offers/new/+page.svelte
+++ b/src/routes/(customer)/ride-offers/new/+page.svelte
@@ -7,8 +7,6 @@
 	import { t } from '$lib/i18n/translation';
 	import {
 		ArrowUpDown,
-		MapPin,
-		MapPinCheckInside,
 		EllipsisVertical,
 		ChevronRightIcon,
 		LoaderCircle,

--- a/src/routes/(customer)/ride-offers/new/+page.svelte
+++ b/src/routes/(customer)/ride-offers/new/+page.svelte
@@ -651,8 +651,10 @@
 							<div class="flex items-center text-muted-foreground">
 								<EllipsisVertical class="ml-2 mr-6" />
 								{formatDurationSec(
-									floorToMinute(page.state.selectedItinerary?.duration /
-										(1 + SCHEDULED_TIME_BUFFER_DROPOFF_RELATIVE))
+									floorToMinute(
+										page.state.selectedItinerary?.duration /
+											(1 + SCHEDULED_TIME_BUFFER_DROPOFF_RELATIVE)
+									)
 								)}
 								{t.rideShare.travelTimeOnly}
 							</div>

--- a/src/routes/(customer)/ride-offers/new/+page.svelte
+++ b/src/routes/(customer)/ride-offers/new/+page.svelte
@@ -613,15 +613,19 @@
 			</Card.Root>
 
 			{#if page.state.selectedItinerary && !loading}
-				<Card.Root class="hover:bg-accent/40" role=button onclick={() =>
-					pushState('', {
-						showMap: true,
-						selectedItinerary: page.state.selectedItinerary,
-						rideShareRouteDistanceMeters: page.state.rideShareRouteDistanceMeters
-					})}>
+				<Card.Root
+					class="hover:bg-accent/40"
+					role="button"
+					onclick={() =>
+						pushState('', {
+							showMap: true,
+							selectedItinerary: page.state.selectedItinerary,
+							rideShareRouteDistanceMeters: page.state.rideShareRouteDistanceMeters
+						})}
+				>
 					<Card.Header>
 						<Card.Title class="flex items-center gap-2 text-base">
-						{t.rideShare.calculatedRoute}
+							{t.rideShare.calculatedRoute}
 						</Card.Title>
 					</Card.Header>
 					<Card.Content>
@@ -644,7 +648,10 @@
 							</div>
 							<div class="flex items-center text-muted-foreground">
 								<EllipsisVertical class="ml-2 mr-6" />
-								{formatDurationSec(page.state.selectedItinerary?.duration / (1+SCHEDULED_TIME_BUFFER_DROPOFF_RELATIVE)) }
+								{formatDurationSec(
+									page.state.selectedItinerary?.duration /
+										(1 + SCHEDULED_TIME_BUFFER_DROPOFF_RELATIVE)
+								)}
 								{t.rideShare.travelTimeOnly}
 							</div>
 							<div class="flex items-center overflow-hidden">

--- a/src/routes/(customer)/ride-offers/new/+page.svelte
+++ b/src/routes/(customer)/ride-offers/new/+page.svelte
@@ -190,6 +190,8 @@
 		return undefined;
 	});
 
+	let durationDirect = $state(0);
+	
 	async function doRouting() {
 		loading = true;
 		msg = undefined;
@@ -213,12 +215,13 @@
 					return response.json();
 				})
 				.then((j) => {
-					if (!j || !j.end || !j.start) {
+					if (!j || !j.end || !j.start || !j.duration) {
 						msg = j;
 						loading = false;
 						replaceState('', {});
 						return;
 					}
+					durationDirect = j.duration / 1000;
 					const it: Itinerary = {
 						duration: (j!.end - j!.start) / 1000,
 						startTime: new Date(j!.start).toISOString(),
@@ -650,12 +653,7 @@
 							</div>
 							<div class="flex items-center text-muted-foreground">
 								<EllipsisVertical class="ml-2 mr-6" />
-								{formatDurationSec(
-									floorToMinute(
-										page.state.selectedItinerary?.duration /
-											(1 + SCHEDULED_TIME_BUFFER_DROPOFF_RELATIVE)
-									)
-								)}
+								{formatDurationSec(durationDirect)}
 								{t.rideShare.travelTimeOnly}
 							</div>
 							<div class="flex items-center overflow-hidden">

--- a/src/routes/(customer)/ride-offers/new/+page.svelte
+++ b/src/routes/(customer)/ride-offers/new/+page.svelte
@@ -47,6 +47,7 @@
 	import * as Card from '$lib/shadcn/card';
 	import { shiftDayIdxBackward } from '$lib/util/shiftDayIdx';
 	import { preparedDetourEllipseToGeoJSON, prepareDetourEllipse } from '$lib/util/booking/ellipse';
+	import { SCHEDULED_TIME_BUFFER_DROPOFF_RELATIVE } from '$lib/constants';
 
 	const { data, form } = $props();
 
@@ -611,18 +612,19 @@
 				</Card.Content>
 			</Card.Root>
 
-			<div class="flex items-center justify-center">
-				{#if page.state.selectedItinerary && !loading}
-					<Button
-						variant="outline"
-						onclick={() =>
-							pushState('', {
-								showMap: true,
-								selectedItinerary: page.state.selectedItinerary,
-								rideShareRouteDistanceMeters: page.state.rideShareRouteDistanceMeters
-							})}
-						class="size-fit text-base"
-					>
+			{#if page.state.selectedItinerary && !loading}
+				<Card.Root class="hover:bg-accent/40" role=button onclick={() =>
+					pushState('', {
+						showMap: true,
+						selectedItinerary: page.state.selectedItinerary,
+						rideShareRouteDistanceMeters: page.state.rideShareRouteDistanceMeters
+					})}>
+					<Card.Header>
+						<Card.Title class="flex items-center gap-2 text-base">
+						{t.rideShare.calculatedRoute}
+						</Card.Title>
+					</Card.Header>
+					<Card.Content>
 						<div class="flex-row">
 							<div class="flex items-center">
 								<MapPin class="mr-2 h-5 w-5" />
@@ -634,14 +636,20 @@
 									scheduledTimestamp={page.state.selectedItinerary?.startTime}
 									timestamp={page.state.selectedItinerary?.startTime}
 								/>
-								{t.departure}
+								{from.label ? from.label : t.departure}
 							</div>
 							<div class="flex items-center text-muted-foreground">
 								<EllipsisVertical class="mr-2 h-5 w-5" />
 								{formatDurationSec(page.state.selectedItinerary?.duration)}
+								{t.rideShare.maxTime}
 							</div>
-							<div class="flex items-center">
-								<MapPinCheckInside class="mr-2 h-5 w-5" />
+							<div class="flex items-center text-muted-foreground">
+								<EllipsisVertical class="mr-2 h-5 w-5" />
+								{formatDurationSec(page.state.selectedItinerary?.duration / (1+SCHEDULED_TIME_BUFFER_DROPOFF_RELATIVE)) }
+								{t.rideShare.travelTimeOnly}
+							</div>
+							<div class="flex w-fit items-center">
+								<MapPinCheckInside class="size-5 mr-2" />
 								<Time
 									variant="schedule"
 									class="mr-4 w-auto font-semibold"
@@ -650,14 +658,15 @@
 									scheduledTimestamp={page.state.selectedItinerary?.endTime}
 									timestamp={page.state.selectedItinerary?.endTime}
 								/>
-								{t.arrival}
+								{to.label ? to.label : t.arrival}
 							</div>
 						</div>
-					</Button>
-				{:else if loading}
-					<LoaderCircle class="h-6 w-6 animate-spin" />
-				{/if}
-			</div>
+					</Card.Content>
+				</Card.Root>
+			{:else if loading}
+				<LoaderCircle class="h-6 w-6 animate-spin" />
+			{/if}
+
 			<Message class="mb-6" msg={form?.msg || msg} />
 
 			<p>{t.ride.outro}</p>

--- a/src/routes/(customer)/ride-offers/new/+page.svelte
+++ b/src/routes/(customer)/ride-offers/new/+page.svelte
@@ -45,7 +45,6 @@
 	import * as Card from '$lib/shadcn/card';
 	import { shiftDayIdxBackward } from '$lib/util/shiftDayIdx';
 	import { preparedDetourEllipseToGeoJSON, prepareDetourEllipse } from '$lib/util/booking/ellipse';
-	import { SCHEDULED_TIME_BUFFER_DROPOFF_RELATIVE } from '$lib/constants';
 
 	const { data, form } = $props();
 

--- a/src/routes/(customer)/ride-offers/new/+page.svelte
+++ b/src/routes/(customer)/ride-offers/new/+page.svelte
@@ -191,7 +191,7 @@
 	});
 
 	let durationDirect = $state(0);
-	
+
 	async function doRouting() {
 		loading = true;
 		msg = undefined;

--- a/src/routes/(customer)/ride-offers/new/+page.svelte
+++ b/src/routes/(customer)/ride-offers/new/+page.svelte
@@ -214,7 +214,7 @@
 				})
 				.then((j) => {
 					if (!j || !j.end || !j.start) {
-						msg = { type: 'error', text: 'noRouteFound' };
+						msg = j;
 						loading = false;
 						replaceState('', {});
 						return;


### PR DESCRIPTION
- Kachel für berechnete Route ist jetzt genau so breit wie die anderen Kacheln
- Start und Ziel werden jetzt explizit benannt
- gepufferte Fahrzeit könnte lang wirken -> wird jetzt augeschlüsselt in Maximum bei Mitnahme und reine Fahrzeit
<img width="404" height="1077" alt="image" src="https://github.com/user-attachments/assets/cdf26c4f-ec7a-49c9-b964-c4064fb3a6a5" />

closes #658 